### PR TITLE
Add Tinyauth + Pocket ID integration for Proxmox auth

### DIFF
--- a/deployments/deploy_caddy.yml
+++ b/deployments/deploy_caddy.yml
@@ -1,6 +1,6 @@
 ---
-# Deploy Caddy (reverse proxy + Cloudflare Tunnel).
-# Pass cloudflare_api_token and cloudflare_tunnel_token via vars file: make deploy-caddy or -e "@vars/caddy_vars.yml"
+# Deploy Caddy (reverse proxy + Cloudflare Tunnel). Tinyauth runs on PocketID host — see deploy_pocketid.
+# Vars: -e "@vars/caddy_vars.yml"
 - name: Deploy Caddy
   hosts: caddy_host
   become: yes

--- a/deployments/deploy_pocketid.yml
+++ b/deployments/deploy_pocketid.yml
@@ -1,6 +1,6 @@
 ---
-# Deploy PocketID (OIDC/Passkey provider at https://id.mol.la).
-# Pass pocketid_encryption_key via vars: -e "@vars/pocketid_vars.yml" (generate with: openssl rand -base64 32)
+# Deploy Pocket ID + Tinyauth (identity portal at id.mol.la).
+# Vars: -e "@vars/pocketid_vars.yml"
 - name: Deploy PocketID
   hosts: pocketid_host
   become: yes

--- a/roles/caddy/templates/Caddyfile.j2
+++ b/roles/caddy/templates/Caddyfile.j2
@@ -1,14 +1,12 @@
+# Tinyauth forward-auth — validates session via Pocket ID (Tinyauth on PocketID host :1412)
 (protected) {
-    forward_auth 192.168.178.122:1411 {
-        uri /api/forward-auth
-        
+    forward_auth 192.168.178.122:1412 {
+        uri /api/auth/caddy
         header_up X-Forwarded-Host {host}
         header_up X-Forwarded-Proto https
         header_up X-Forwarded-Method {method}
         header_up X-Forwarded-Uri {uri}
-        header_up Host id.mol.la
-        
-        copy_headers Remote-User Remote-Email Remote-Name
+        copy_headers Remote-User Remote-Email Remote-Name Remote-Groups
     }
 }
 
@@ -31,9 +29,14 @@ http://one.mol.la, one.mol.la {
     }
 }
 
-# PocketID — OIDC/Passkey
+# id.mol.la — Pocket ID UI + Tinyauth callback (single identity portal, cookie consistency)
 http://id.mol.la, id.mol.la {
-	reverse_proxy 192.168.178.122:1411
+    handle /api/oauth/* {
+        reverse_proxy 192.168.178.122:1412
+    }
+    handle {
+        reverse_proxy 192.168.178.122:1411
+    }
 }
 
 # AdGuard Primary — DNS UI

--- a/roles/caddy/templates/compose.yml.j2
+++ b/roles/caddy/templates/compose.yml.j2
@@ -1,5 +1,5 @@
 # Caddy + Cloudflare Tunnel — host network for seamless internal/external routing.
-# Pass cloudflare_api_token and cloudflare_tunnel_token via vars (e.g. vars/caddy_vars.yml).
+# Tinyauth runs on PocketID host (192.168.178.122:1412) for id.mol.la cookie consistency.
 services:
   caddy:
     build:

--- a/roles/pocketid/handlers/main.yml
+++ b/roles/pocketid/handlers/main.yml
@@ -2,3 +2,7 @@
 - name: Restart PocketID service
   ansible.builtin.command:
     cmd: docker restart pocketid-{{ inventory_hostname }}
+
+- name: Restart Tinyauth service
+  ansible.builtin.command:
+    cmd: docker restart tinyauth-{{ inventory_hostname }}

--- a/roles/pocketid/tasks/main.yml
+++ b/roles/pocketid/tasks/main.yml
@@ -12,7 +12,9 @@
     dest: "/opt/compose/pocketid-{{ inventory_hostname }}/compose.yml"
     mode: '0644'
   no_log: true
-  notify: Restart PocketID service
+  notify:
+    - Restart PocketID service
+    - Restart Tinyauth service
 
 - name: Start PocketID with Docker Compose
   community.docker.docker_compose_v2:

--- a/roles/pocketid/templates/compose.yml.j2
+++ b/roles/pocketid/templates/compose.yml.j2
@@ -1,6 +1,28 @@
-# Pocket ID — OIDC/Passkey provider at https://id.mol.la
-# Pass pocketid_encryption_key via vars (e.g. -e "@vars/pocketid_vars.yml"). Generate with: openssl rand -base64 32
+# Pocket ID + Tinyauth — OIDC/Passkey at id.mol.la, Tinyauth auth middleware on same host for cookie consistency
+# Vars: pocketid_encryption_key, tinyauth_pocketid_client_id, tinyauth_pocketid_client_secret
+# OIDC client callback URL: https://id.mol.la/api/oauth/callback/pocketid
 services:
+  tinyauth:
+    image: ghcr.io/steveiliop56/tinyauth:v4
+    container_name: tinyauth-{{ inventory_hostname }}
+    restart: unless-stopped
+    ports:
+      - "1412:3000"
+    environment:
+      APP_URL: "https://id.mol.la"
+      SECURE_COOKIE: "true"
+      OAUTH_AUTO_REDIRECT: "pocketid"
+      USERS: "{{ tinyauth_users | default('oauth_placeholder:$$2a$$10$$UdLYoJ5lgPsC0RKqYH/jMua7zIn0g9kPqWmhYayJYLaZQ/FTmH2/u') }}"
+      PROVIDERS_POCKETID_CLIENT_ID: "{{ tinyauth_pocketid_client_id }}"
+      PROVIDERS_POCKETID_CLIENT_SECRET: "{{ tinyauth_pocketid_client_secret }}"
+      PROVIDERS_POCKETID_AUTH_URL: "https://id.mol.la/authorize"
+      PROVIDERS_POCKETID_TOKEN_URL: "https://id.mol.la/api/oidc/token"
+      PROVIDERS_POCKETID_USER_INFO_URL: "https://id.mol.la/api/oidc/userinfo"
+      PROVIDERS_POCKETID_REDIRECT_URL: "https://id.mol.la/api/oauth/callback/pocketid"
+      PROVIDERS_POCKETID_SCOPES: "openid email profile groups"
+      PROVIDERS_POCKETID_NAME: "Pocket ID"
+      TRUSTED_PROXIES: "192.168.178.121,127.0.0.1,::1"
+
   pocketid:
     image: {{ pocketid_image | default('ghcr.io/pocket-id/pocket-id:v2') }}
     container_name: pocketid-{{ inventory_hostname }}


### PR DESCRIPTION
- Add Tinyauth to PocketID compose (port 1412) on id.mol.la for cookie consistency
- Update Caddyfile: forward_auth to Tinyauth, id.mol.la routes /api/oauth/* to Tinyauth
- Remove Tinyauth from Caddy compose (moved to PocketID host)
- Add Tinyauth vars to pocketid_vars.yml (client id/secret from OIDC client)
- Add restart handlers for Tinyauth in PocketID role
- OIDC callback: https://id.mol.la/api/oauth/callback/pocketid