### PR TITLE
fix: Route Tinyauth assets at id.mol.la

### DIFF
--- a/roles/caddy/templates/Caddyfile.j2
+++ b/roles/caddy/templates/Caddyfile.j2
@@ -34,7 +34,7 @@ http://one.mol.la, one.mol.la {
 http://id.mol.la, id.mol.la {
     # Match ONLY Tinyauth-specific paths (Pocket ID keeps /api/oidc/*, /authorize, etc.)
     @tinyauth_paths {
-        path /api/oauth/* /api/context/* /api/auth/* /api/user/* /api/resources/* /api/healthz /login* /continue* /error* /unauthorized*
+        path /api/oauth/* /api/context/* /api/auth/* /api/user/* /api/resources/* /api/healthz /login* /continue* /error* /unauthorized* /assets/* /site.webmanifest /favicon.ico /background.jpg
     }
 
     # Route Tinyauth traffic


### PR DESCRIPTION
Add /assets/*, /site.webmanifest, favicon.ico, background.jpg to @tinyauth_paths so Tinyauth login page loads CSS/JS instead of receiving HTML from Pocket ID (causing MIME type errors).