### PR TITLE
Add PostgreSQL LXC (130) and per-container overrides

### DIFF
--- a/inventory/hosts
+++ b/inventory/hosts
@@ -12,10 +12,15 @@ caddy ansible_host=192.168.178.121
 [pocketid_host]
 pocketid ansible_host=192.168.178.122
 
+# PostgreSQL
+[postgresql_host]
+postgresql ansible_host=192.168.178.130
+
 [core:children]
 ansible_host
 caddy_host
 pocketid_host
+postgresql_host
 
 # DNS
 [adguard_primary_host]

--- a/roles/proxmox_create_lxc/defaults/main.yml
+++ b/roles/proxmox_create_lxc/defaults/main.yml
@@ -32,6 +32,14 @@ proxmox_containers:
     ip: "192.168.178.122/24"
     description: "PocketID for identity management"
     unprivileged: 1
+  - vmid: 130
+    hostname: postgresql
+    ip: "192.168.178.130/24"
+    description: "PostgreSQL database server"
+    unprivileged: 1
+    cores: 2
+    memory: 2048
+    disk: "local-lvm:20"
   - vmid: 253
     hostname: adguard-primary
     ip: "192.168.178.253/24"

--- a/roles/proxmox_create_lxc/tasks/main.yml
+++ b/roles/proxmox_create_lxc/tasks/main.yml
@@ -17,15 +17,14 @@
     ostemplate: "{{ proxmox_ostemplate }}"
     password: "{{ proxmox_container_password }}"
     pubkey: "{{ proxmox_ssh_pubkey }}"
-    disk: "{{ proxmox_disk }}"
-    cores: "{{ proxmox_cores }}"
-    memory: "{{ proxmox_memory }}"
-    swap: "{{ proxmox_swap }}"
+    disk: "{{ item.disk | default(proxmox_disk) }}"
+    cores: "{{ item.cores | default(proxmox_cores) }}"
+    memory: "{{ item.memory | default(proxmox_memory) }}"
+    swap: "{{ item.swap | default(proxmox_swap) }}"
     netif:
       net0: "name=eth0,bridge={{ proxmox_bridge }},gw={{ proxmox_gw }},ip={{ item.ip }}"
     unprivileged: "{{ item.unprivileged | default(1) }}"
-    features:
-      - nesting=1
+    features: "{{ item.features | default(['nesting=1']) }}"
     onboot: true
     description: "{{ item.description }}"
     state: present


### PR DESCRIPTION
- Add postgres-1: 192.168.178.130, 2 cores, 2GB RAM, 10GB disk
- Support per-container cores, memory, disk, swap, features
- Add postgresql_host to inventory