### PR TITLE
Add OIDC (PocketID) auth to Vault config role

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ ansible-playbook deployments/deploy_pocketid.yml -e "@vars/pocketid_vars.yml"
 ansible-playbook deployments/deploy_vault.yml
 ```
 
-**Configure Vault (kv-v2, AppRole, policies):**
+**Configure Vault (kv-v2, AppRole, OIDC, policies):**
 ```bash
-ansible-playbook deployments/configure_vault.yml -e "vault_token=<root-token>"
+ansible-playbook deployments/configure_vault.yml -e "vault_token=<root-token>" -e "@vars/vault_config_vars.yml"
 ```
 
 > After deploying a new service that Caddy should proxy, redeploy Caddy to update routes.

--- a/deployments/configure_vault.yml
+++ b/deployments/configure_vault.yml
@@ -1,6 +1,6 @@
 ---
-# Configure Vault: kv-v2 engine, AppRole auth, policies.
-# Usage: ansible-playbook deployments/configure_vault.yml -e "vault_token=<root-token>"
+# Configure Vault: kv-v2 engine, AppRole auth, OIDC (PocketID), policies.
+# Usage: ansible-playbook deployments/configure_vault.yml -e "vault_token=<root-token>" -e "@vars/vault_config_vars.yml"
 - name: Configure Vault
   hosts: localhost
   connection: local

--- a/roles/vault_config/defaults/main.yml
+++ b/roles/vault_config/defaults/main.yml
@@ -6,3 +6,9 @@ vault_approle_token_ttl: "1h"
 vault_approle_token_max_ttl: "4h"
 vault_approle_secret_id_ttl: "720h"
 vault_policy_name: "ansible-read-policy"
+
+# OIDC (PocketID)
+vault_oidc_discovery_url: "https://id.mol.la"
+vault_oidc_role_name: "homelab-admin"
+vault_oidc_redirect_uris:
+  - "https://vault.mol.la/ui/vault/auth/oidc/oidc/callback"

--- a/roles/vault_config/tasks/main.yml
+++ b/roles/vault_config/tasks/main.yml
@@ -68,3 +68,60 @@
       - "role_id: {{ approle_role_id.data.data.role_id }}"
       - "secret_id: {{ approle_secret_id.data.data.secret_id }}"
       - "Store these securely. The secret_id cannot be retrieved again."
+
+# --- OIDC (PocketID) ---
+
+- name: Write admin policy
+  community.hashi_vault.vault_write:
+    url: "{{ vault_addr }}"
+    token: "{{ vault_token }}"
+    path: "sys/policies/acl/admin"
+    data:
+      policy: "{{ lookup('template', 'admin-policy.hcl.j2') }}"
+
+- name: Enable oidc auth method
+  community.hashi_vault.vault_write:
+    url: "{{ vault_addr }}"
+    token: "{{ vault_token }}"
+    path: "sys/auth/oidc"
+    data:
+      type: oidc
+  register: oidc_mount
+  failed_when:
+    - oidc_mount is failed
+    - "'already in use' not in (oidc_mount.msg | default(''))"
+
+- name: Configure oidc auth method
+  community.hashi_vault.vault_write:
+    url: "{{ vault_addr }}"
+    token: "{{ vault_token }}"
+    path: "auth/oidc/config"
+    data:
+      oidc_discovery_url: "{{ vault_oidc_discovery_url }}"
+      oidc_client_id: "{{ vault_oidc_client_id }}"
+      oidc_client_secret: "{{ vault_oidc_client_secret }}"
+      default_role: "{{ vault_oidc_role_name }}"
+  no_log: true
+
+- name: Create oidc role
+  community.hashi_vault.vault_write:
+    url: "{{ vault_addr }}"
+    token: "{{ vault_token }}"
+    path: "auth/oidc/role/{{ vault_oidc_role_name }}"
+    data:
+      user_claim: "email"
+      allowed_redirect_uris: "{{ vault_oidc_redirect_uris }}"
+      token_policies:
+        - admin
+      oidc_scopes:
+        - openid
+        - profile
+        - email
+
+- name: Tune oidc auth to be listed first
+  community.hashi_vault.vault_write:
+    url: "{{ vault_addr }}"
+    token: "{{ vault_token }}"
+    path: "sys/auth/oidc/tune"
+    data:
+      listing_visibility: "unauth"

--- a/roles/vault_config/templates/admin-policy.hcl.j2
+++ b/roles/vault_config/templates/admin-policy.hcl.j2
@@ -1,0 +1,4 @@
+# Full admin access to all paths
+path "*" {
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}

--- a/vars/vault_config_vars.yml.example
+++ b/vars/vault_config_vars.yml.example
@@ -1,0 +1,5 @@
+# Vault OIDC — PocketID client credentials
+# Create OIDC client at https://id.mol.la/settings/admin/oidc-clients
+# Callback URL: https://vault.mol.la/ui/vault/auth/oidc/oidc/callback
+vault_oidc_client_id: "CHANGE_ME"
+vault_oidc_client_secret: "CHANGE_ME"


### PR DESCRIPTION
- Enable oidc auth method with PocketID as provider
- Create homelab-admin OIDC role with admin policy
- Add admin policy template (full access)
- Set oidc listing_visibility to unauth for login page
- Add vault_config_vars.yml.example for OIDC client credentials