### PR TITLE
Add MySQL role with Vault-backed secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ ansible-playbook deployments/configure_vault.yml -e "vault_token=<root-token>" -
 ansible-playbook deployments/deploy_postgresql.yml -e "@vars/vault_auth_vars.yml" -e "@vars/postgresql_apps.yml"
 ```
 
+**MySQL (database server):**
+```bash
+ansible-playbook deployments/deploy_mysql.yml -e "@vars/vault_auth_vars.yml" -e "@vars/mysql_apps.yml"
+```
+
 > After deploying a new service that Caddy should proxy, redeploy Caddy to update routes.
 
 ---

--- a/deployments/deploy_mysql.yml
+++ b/deployments/deploy_mysql.yml
@@ -1,0 +1,8 @@
+---
+# Deploy MySQL — passwords fetched from Vault.
+# Usage: ansible-playbook deployments/deploy_mysql.yml -e "@vars/vault_auth_vars.yml" -e "@vars/mysql_apps.yml"
+- name: Deploy MySQL
+  hosts: mysql_host
+  become: true
+  roles:
+    - mysql

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,3 +4,4 @@ collections:
   - name: community.docker
   - name: community.hashi_vault
   - name: community.postgresql
+  - name: community.mysql

--- a/roles/mysql/defaults/main.yml
+++ b/roles/mysql/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+mysql_homelab_network: "192.168.178.%"
+mysql_vault_secret_path: "kv/homelab/data/mysql"
+mysql_root_vault_key: "root"
+
+# List of apps — each gets a user, db, and remote access grant.
+# Password is fetched from Vault using vault_key.
+mysql_apps:
+  - user: homelab
+    db: homelab
+    vault_key: homelab

--- a/roles/mysql/handlers/main.yml
+++ b/roles/mysql/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart MySQL
+  ansible.builtin.service:
+    name: mysql
+    state: restarted

--- a/roles/mysql/tasks/create_app.yml
+++ b/roles/mysql/tasks/create_app.yml
@@ -1,0 +1,16 @@
+---
+- name: Create MySQL database {{ app.db }}
+  community.mysql.mysql_db:
+    name: "{{ app.db }}"
+    state: present
+    login_unix_socket: /var/run/mysqld/mysqld.sock
+
+- name: Create MySQL user {{ app.user }}
+  community.mysql.mysql_user:
+    name: "{{ app.user }}"
+    host: "{{ mysql_homelab_network }}"
+    password: "{{ mysql_vault_secret.data.data.data[app.vault_key] }}"
+    priv: "{{ app.db }}.*:ALL"
+    state: present
+    login_unix_socket: /var/run/mysqld/mysqld.sock
+  no_log: true

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -1,0 +1,51 @@
+---
+- name: Install MySQL and Python bindings
+  ansible.builtin.apt:
+    name:
+      - mysql-server
+      - python3-pymysql
+    state: present
+    update_cache: true
+
+- name: Ensure MySQL service is running and enabled
+  ansible.builtin.service:
+    name: mysql
+    state: started
+    enabled: true
+
+- name: Configure MySQL to listen on all interfaces
+  ansible.builtin.lineinfile:
+    path: /etc/mysql/mysql.conf.d/mysqld.cnf
+    regexp: "^bind-address"
+    line: "bind-address = 0.0.0.0"
+  notify: Restart MySQL
+
+- name: Flush handlers before creating users/databases
+  ansible.builtin.meta: flush_handlers
+
+- name: Fetch passwords from Vault
+  community.hashi_vault.vault_read:
+    url: "{{ vault_addr }}"
+    path: "{{ mysql_vault_secret_path }}"
+    auth_method: approle
+    role_id: "{{ vault_role_id }}"
+    secret_id: "{{ vault_secret_id }}"
+  register: mysql_vault_secret
+  delegate_to: localhost
+  become: false
+
+- name: Set MySQL root password
+  community.mysql.mysql_user:
+    name: root
+    host: localhost
+    password: "{{ mysql_vault_secret.data.data.data[mysql_root_vault_key] }}"
+    login_unix_socket: /var/run/mysqld/mysqld.sock
+    state: present
+  no_log: true
+
+- name: Create users and databases
+  ansible.builtin.include_tasks: create_app.yml
+  loop: "{{ mysql_apps }}"
+  loop_control:
+    loop_var: app
+    label: "{{ app.user }}/{{ app.db }}"

--- a/vars/mysql_apps.yml
+++ b/vars/mysql_apps.yml
@@ -1,0 +1,6 @@
+# MySQL apps — each entry creates a user, database, and remote access grant.
+# Password is fetched from Vault at kv/homelab/mysql using vault_key.
+mysql_apps:
+  - user: homelab
+    db: homelab
+    vault_key: homelab


### PR DESCRIPTION
- Multi-app support: loop over mysql_apps for user/db/grants
- Passwords fetched from Vault via AppRole at kv/homelab/mysql
- Default user/db: homelab
- Remote access from 192.168.178.% subnet
- Add community.mysql to requirements.yml