### PR TITLE
Add Redis role with Vault-backed password

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ ansible-playbook deployments/deploy_postgresql.yml -e "@vars/vault_auth_vars.yml
 ansible-playbook deployments/deploy_mysql.yml -e "@vars/vault_auth_vars.yml" -e "@vars/mysql_apps.yml"
 ```
 
+**Redis (in-memory data store):**
+```bash
+ansible-playbook deployments/deploy_redis.yml -e "@vars/vault_auth_vars.yml"
+```
+
 > After deploying a new service that Caddy should proxy, redeploy Caddy to update routes.
 
 ---

--- a/deployments/deploy_redis.yml
+++ b/deployments/deploy_redis.yml
@@ -1,0 +1,8 @@
+---
+# Deploy Redis — password fetched from Vault.
+# Usage: ansible-playbook deployments/deploy_redis.yml -e "@vars/vault_auth_vars.yml"
+- name: Deploy Redis
+  hosts: redis_host
+  become: true
+  roles:
+    - redis

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+redis_vault_secret_path: "kv/homelab/data/redis"
+redis_vault_key: "password"
+redis_bind: "0.0.0.0"
+redis_maxmemory: "768mb"
+redis_maxmemory_policy: "allkeys-lru"

--- a/roles/redis/handlers/main.yml
+++ b/roles/redis/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart Redis
+  ansible.builtin.service:
+    name: redis-server
+    state: restarted

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+- name: Install Redis
+  ansible.builtin.apt:
+    name: redis-server
+    state: present
+    update_cache: true
+
+- name: Fetch password from Vault
+  community.hashi_vault.vault_read:
+    url: "{{ vault_addr }}"
+    path: "{{ redis_vault_secret_path }}"
+    auth_method: approle
+    role_id: "{{ vault_role_id }}"
+    secret_id: "{{ vault_secret_id }}"
+  register: redis_vault_secret
+  delegate_to: localhost
+  become: false
+
+- name: Deploy redis.conf
+  ansible.builtin.template:
+    src: redis.conf.j2
+    dest: /etc/redis/redis.conf
+    mode: '0640'
+    owner: redis
+    group: redis
+  notify: Restart Redis
+  no_log: true
+
+- name: Ensure Redis service is running and enabled
+  ansible.builtin.service:
+    name: redis-server
+    state: started
+    enabled: true

--- a/roles/redis/templates/redis.conf.j2
+++ b/roles/redis/templates/redis.conf.j2
@@ -1,0 +1,30 @@
+# Redis configuration — managed by Ansible
+
+bind {{ redis_bind }}
+protected-mode yes
+port 6379
+
+requirepass {{ redis_vault_secret.data.data.data[redis_vault_key] }}
+
+maxmemory {{ redis_maxmemory }}
+maxmemory-policy {{ redis_maxmemory_policy }}
+
+# Persistence
+save 900 1
+save 300 10
+save 60 10000
+dbfilename dump.rdb
+dir /var/lib/redis
+
+# Logging
+loglevel notice
+logfile /var/log/redis/redis-server.log
+
+# Security
+rename-command FLUSHALL ""
+rename-command FLUSHDB ""
+rename-command CONFIG ""
+
+daemonize yes
+supervised systemd
+pidfile /run/redis/redis-server.pid


### PR DESCRIPTION
- Install redis-server, configure via template
- Password fetched from Vault at kv/homelab/redis
- Bind 0.0.0.0, maxmemory 768mb, allkeys-lru eviction
- Dangerous commands disabled (FLUSHALL, FLUSHDB, CONFIG)