### PR TITLE
Add MongoDB role with Vault-backed secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ ansible-playbook deployments/deploy_mysql.yml -e "@vars/vault_auth_vars.yml" -e 
 ansible-playbook deployments/deploy_redis.yml -e "@vars/vault_auth_vars.yml"
 ```
 
+**MongoDB (document database):**
+```bash
+ansible-playbook deployments/deploy_mongodb.yml -e "@vars/vault_auth_vars.yml" -e "@vars/mongodb_apps.yml"
+```
+
 > After deploying a new service that Caddy should proxy, redeploy Caddy to update routes.
 
 ---

--- a/deployments/deploy_mongodb.yml
+++ b/deployments/deploy_mongodb.yml
@@ -1,0 +1,8 @@
+---
+# Deploy MongoDB — passwords fetched from Vault.
+# Usage: ansible-playbook deployments/deploy_mongodb.yml -e "@vars/vault_auth_vars.yml" -e "@vars/mongodb_apps.yml"
+- name: Deploy MongoDB
+  hosts: mongodb_host
+  become: true
+  roles:
+    - mongodb

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,3 +5,4 @@ collections:
   - name: community.hashi_vault
   - name: community.postgresql
   - name: community.mysql
+  - name: community.mongodb

--- a/roles/mongodb/defaults/main.yml
+++ b/roles/mongodb/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+mongodb_version: "8.0"
+mongodb_vault_secret_path: "kv/homelab/data/mongodb"
+mongodb_admin_user: "site_admin"
+mongodb_admin_vault_key: "admin_password"
+
+# List of apps — each gets a user, db, and readWrite role.
+# Password is fetched from Vault using vault_key.
+mongodb_apps:
+  - user: homelab
+    db: homelab
+    vault_key: homelab

--- a/roles/mongodb/handlers/main.yml
+++ b/roles/mongodb/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart MongoDB
+  ansible.builtin.service:
+    name: mongod
+    state: restarted

--- a/roles/mongodb/tasks/create_app.yml
+++ b/roles/mongodb/tasks/create_app.yml
@@ -1,0 +1,15 @@
+---
+- name: Create MongoDB user {{ app.user }} on {{ app.db }}
+  community.mongodb.mongodb_user:
+    database: "{{ app.db }}"
+    name: "{{ app.user }}"
+    password: "{{ mongo_vault_secret.data.data.data[app.vault_key] }}"
+    roles:
+      - db: "{{ app.db }}"
+        role: readWrite
+    login_user: "{{ mongodb_admin_user }}"
+    login_password: "{{ mongo_vault_secret.data.data.data[mongodb_admin_vault_key] }}"
+    login_host: localhost
+    login_port: 27017
+    state: present
+  no_log: true

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -1,0 +1,75 @@
+---
+- name: Install dependencies
+  ansible.builtin.apt:
+    name:
+      - gnupg
+      - curl
+      - python3-pymongo
+    state: present
+    update_cache: true
+
+- name: Import MongoDB GPG key
+  ansible.builtin.apt_key:
+    url: "https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc"
+    state: present
+
+- name: Add MongoDB repository
+  ansible.builtin.apt_repository:
+    repo: "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/{{ mongodb_version }} multiverse"
+    filename: mongodb-org-{{ mongodb_version }}
+    state: present
+
+- name: Install MongoDB
+  ansible.builtin.apt:
+    name: mongodb-org
+    state: present
+    update_cache: true
+
+- name: Deploy mongod.conf
+  ansible.builtin.template:
+    src: mongod.conf.j2
+    dest: /etc/mongod.conf
+    mode: '0644'
+    owner: root
+    group: root
+  notify: Restart MongoDB
+
+- name: Ensure MongoDB service is running and enabled
+  ansible.builtin.service:
+    name: mongod
+    state: started
+    enabled: true
+
+- name: Flush handlers
+  ansible.builtin.meta: flush_handlers
+
+- name: Fetch passwords from Vault
+  community.hashi_vault.vault_read:
+    url: "{{ vault_addr }}"
+    path: "{{ mongodb_vault_secret_path }}"
+    auth_method: approle
+    role_id: "{{ vault_role_id }}"
+    secret_id: "{{ vault_secret_id }}"
+  register: mongo_vault_secret
+  delegate_to: localhost
+  become: false
+
+- name: Create admin user
+  community.mongodb.mongodb_user:
+    database: admin
+    name: "{{ mongodb_admin_user }}"
+    password: "{{ mongo_vault_secret.data.data.data[mongodb_admin_vault_key] }}"
+    roles:
+      - db: admin
+        role: root
+    login_host: localhost
+    login_port: 27017
+    state: present
+  no_log: true
+
+- name: Create app users and databases
+  ansible.builtin.include_tasks: create_app.yml
+  loop: "{{ mongodb_apps }}"
+  loop_control:
+    loop_var: app
+    label: "{{ app.user }}/{{ app.db }}"

--- a/roles/mongodb/templates/mongod.conf.j2
+++ b/roles/mongodb/templates/mongod.conf.j2
@@ -1,0 +1,19 @@
+# MongoDB configuration — managed by Ansible
+
+storage:
+  dbPath: /var/lib/mongodb
+
+systemLog:
+  destination: file
+  logAppend: true
+  path: /var/log/mongodb/mongod.log
+
+net:
+  port: 27017
+  bindIp: 0.0.0.0
+
+processManagement:
+  timeZoneInfo: /usr/share/zoneinfo
+
+security:
+  authorization: enabled

--- a/vars/mongodb_apps.yml
+++ b/vars/mongodb_apps.yml
@@ -1,0 +1,6 @@
+# MongoDB apps — each entry creates a user with readWrite on its database.
+# Password is fetched from Vault at kv/homelab/mongodb using vault_key.
+mongodb_apps:
+  - user: homelab
+    db: homelab
+    vault_key: homelab


### PR DESCRIPTION
- Install MongoDB 8.0 from official repo
- Create site_admin with root role, per-app users with readWrite
- Passwords fetched from Vault at kv/homelab/mongodb
- Auth enabled, bind 0.0.0.0 for homelab access
- Add community.mongodb to requirements.yml