### PR TITLE
Use mongosh instead of pymongo for MongoDB user management

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -5,4 +5,3 @@ collections:
   - name: community.hashi_vault
   - name: community.postgresql
   - name: community.mysql
-  - name: community.mongodb

--- a/roles/mongodb/tasks/create_app.yml
+++ b/roles/mongodb/tasks/create_app.yml
@@ -1,15 +1,28 @@
 ---
-- name: Create MongoDB user {{ app.user }} on {{ app.db }}
-  community.mongodb.mongodb_user:
-    database: "{{ app.db }}"
-    name: "{{ app.user }}"
-    password: "{{ mongo_vault_secret.data.data.data[app.vault_key] }}"
-    roles:
-      - db: "{{ app.db }}"
-        role: readWrite
-    login_user: "{{ mongodb_admin_user }}"
-    login_password: "{{ mongo_vault_secret.data.data.data[mongodb_admin_vault_key] }}"
-    login_host: localhost
-    login_port: 27017
-    state: present
+- name: Check if user {{ app.user }} exists on {{ app.db }}
+  ansible.builtin.shell: >
+    mongosh --quiet
+    -u "{{ mongodb_admin_user }}"
+    -p "{{ mongo_vault_secret.data.data.data[mongodb_admin_vault_key] }}"
+    --authenticationDatabase admin
+    --eval 'db.getSiblingDB("{{ app.db }}").getUser("{{ app.user }}")'
+    | grep -c '"user"'
+  register: app_user_check
+  changed_when: false
+  failed_when: false
+  no_log: true
+
+- name: Create user {{ app.user }} on {{ app.db }}
+  ansible.builtin.shell: >
+    mongosh --quiet
+    -u "{{ mongodb_admin_user }}"
+    -p "{{ mongo_vault_secret.data.data.data[mongodb_admin_vault_key] }}"
+    --authenticationDatabase admin
+    --eval '
+    db.getSiblingDB("{{ app.db }}").createUser({
+      user: "{{ app.user }}",
+      pwd: "{{ mongo_vault_secret.data.data.data[app.vault_key] }}",
+      roles: [{ role: "readWrite", db: "{{ app.db }}" }]
+    })'
+  when: app_user_check.stdout | default("0") | trim == "0"
   no_log: true

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -4,7 +4,6 @@
     name:
       - gnupg
       - curl
-      - python3-pymongo
     state: present
     update_cache: true
 
@@ -30,8 +29,6 @@
     src: mongod.conf.j2
     dest: /etc/mongod.conf
     mode: '0644'
-    owner: root
-    group: root
   notify: Restart MongoDB
 
 - name: Ensure MongoDB service is running and enabled
@@ -54,17 +51,24 @@
   delegate_to: localhost
   become: false
 
+- name: Check if admin user exists
+  ansible.builtin.shell: >
+    mongosh --quiet --eval
+    'db.getSiblingDB("admin").getUser("{{ mongodb_admin_user }}")'
+    | grep -c '"user"'
+  register: admin_user_check
+  changed_when: false
+  failed_when: false
+
 - name: Create admin user
-  community.mongodb.mongodb_user:
-    database: admin
-    name: "{{ mongodb_admin_user }}"
-    password: "{{ mongo_vault_secret.data.data.data[mongodb_admin_vault_key] }}"
-    roles:
-      - db: admin
-        role: root
-    login_host: localhost
-    login_port: 27017
-    state: present
+  ansible.builtin.shell: >
+    mongosh --quiet --eval '
+    db.getSiblingDB("admin").createUser({
+      user: "{{ mongodb_admin_user }}",
+      pwd: "{{ mongo_vault_secret.data.data.data[mongodb_admin_vault_key] }}",
+      roles: [{ role: "root", db: "admin" }]
+    })'
+  when: admin_user_check.stdout | default("0") | trim == "0"
   no_log: true
 
 - name: Create app users and databases


### PR DESCRIPTION
- Fix Python 3.12 compatibility (readfp removed)
- Remove community.mongodb dependency
- Use mongosh shell for admin and app user creation