### PR TITLE
Disable PKCE for Grafana OAuth to fix PocketID token exchange

### DIFF
--- a/roles/monitoring/templates/grafana.ini.j2
+++ b/roles/monitoring/templates/grafana.ini.j2
@@ -16,3 +16,4 @@ auth_url = {{ grafana_oidc_auth_url }}
 token_url = {{ grafana_oidc_token_url }}
 api_url = {{ grafana_oidc_api_url }}
 role_attribute_path = contains(groups[*], 'owner') && 'Admin' || 'Viewer'
+use_pkce = false


### PR DESCRIPTION
PocketID rejects the code verifier during token exchange when PKCE is enabled, likely due to session state interference from Caddy forward auth.