### PR TITLE
Add node_exporter role and scrape all hosts with Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ ansible-playbook deployments/deploy_mongodb.yml -e "@vars/vault_auth_vars.yml" -
 ansible-playbook deployments/deploy_monitoring.yml -e "@vars/vault_auth_vars.yml"
 ```
 
+**Node Exporter (metrics agent on all hosts):**
+```bash
+ansible-playbook deployments/deploy_node_exporter.yml
+```
+
 > After deploying a new service that Caddy should proxy, redeploy Caddy to update routes.
+> After adding a new LXC, run `deploy_node_exporter.yml` and add the host to `prometheus_scrape_jobs` in the monitoring role defaults, then redeploy monitoring.
 
 ---

--- a/deployments/deploy_node_exporter.yml
+++ b/deployments/deploy_node_exporter.yml
@@ -1,0 +1,8 @@
+---
+# Install prometheus-node-exporter on all managed hosts.
+# Usage: ansible-playbook deployments/deploy_node_exporter.yml
+- name: Deploy node exporter
+  hosts: all_nodes
+  become: true
+  roles:
+    - node_exporter

--- a/inventory/group_vars/proxmox_host.yml
+++ b/inventory/group_vars/proxmox_host.yml
@@ -1,0 +1,3 @@
+---
+# Proxmox VE host — hypervisor
+ansible_user: root

--- a/inventory/hosts
+++ b/inventory/hosts
@@ -1,5 +1,9 @@
 # Homelab inventory — 192.168.178.0/24, gw 192.168.178.1
 
+# Proxmox host
+[proxmox_host]
+proxmox ansible_host=192.168.178.110
+
 # Ansible
 [ansible_host]
 ansible ansible_host=192.168.178.120
@@ -60,3 +64,9 @@ adguard_secondary ansible_host=192.168.178.254
 [dns:children]
 adguard_primary_host
 adguard_secondary_host
+
+# All nodes — used for node_exporter deployment and Prometheus scraping
+[all_nodes:children]
+proxmox_host
+core
+dns

--- a/roles/monitoring/defaults/main.yml
+++ b/roles/monitoring/defaults/main.yml
@@ -8,7 +8,19 @@ prometheus_scrape_jobs:
   - job_name: prometheus
     targets: ["localhost:9090"]
   - job_name: node
-    targets: ["localhost:9100"]
+    targets:
+      - "192.168.178.110:9100"   # proxmox
+      - "192.168.178.120:9100"   # ansible
+      - "192.168.178.121:9100"   # caddy
+      - "192.168.178.122:9100"   # pocketid
+      - "192.168.178.123:9100"   # vault
+      - "192.168.178.124:9100"   # monitoring
+      - "192.168.178.130:9100"   # postgresql
+      - "192.168.178.131:9100"   # mysql
+      - "192.168.178.132:9100"   # redis
+      - "192.168.178.133:9100"   # mongodb
+      - "192.168.178.253:9100"   # adguard-primary
+      - "192.168.178.254:9100"   # adguard-secondary
 
 # Grafana OIDC (PocketID)
 grafana_vault_secret_path: "kv/homelab/data/grafana"

--- a/roles/node_exporter/tasks/main.yml
+++ b/roles/node_exporter/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Install prometheus-node-exporter
+  ansible.builtin.apt:
+    name: prometheus-node-exporter
+    state: present
+    update_cache: true
+
+- name: Ensure node-exporter is running and enabled
+  ansible.builtin.service:
+    name: prometheus-node-exporter
+    state: started
+    enabled: true


### PR DESCRIPTION
- New node_exporter role installs prometheus-node-exporter via apt
- New deploy_node_exporter.yml targets all_nodes group
- Add Proxmox host (192.168.178.110) to inventory
- Add all_nodes group covering proxmox, core, and dns hosts
- Update Prometheus scrape targets to include all 12 hosts