### PR TITLE
Add PVE exporter role for Proxmox VE metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ ansible-playbook deployments/deploy_monitoring.yml -e "@vars/vault_auth_vars.yml
 ansible-playbook deployments/deploy_node_exporter.yml
 ```
 
+**PVE Exporter (Proxmox VE metrics):**
+```bash
+ansible-playbook deployments/deploy_pve_exporter.yml -e "@vars/vault_auth_vars.yml"
+```
+
 > After deploying a new service that Caddy should proxy, redeploy Caddy to update routes.
 > After adding a new LXC, run `deploy_node_exporter.yml` and add the host to `prometheus_scrape_jobs` in the monitoring role defaults, then redeploy monitoring.
 

--- a/deployments/deploy_pve_exporter.yml
+++ b/deployments/deploy_pve_exporter.yml
@@ -1,0 +1,8 @@
+---
+# Deploy Prometheus PVE Exporter on the Proxmox host.
+# Usage: ansible-playbook deployments/deploy_pve_exporter.yml -e "@vars/vault_auth_vars.yml"
+- name: Deploy PVE Exporter
+  hosts: proxmox_host
+  become: true
+  roles:
+    - pve_exporter

--- a/roles/monitoring/defaults/main.yml
+++ b/roles/monitoring/defaults/main.yml
@@ -24,6 +24,10 @@ prometheus_node_targets:
   - { addr: "192.168.178.253:9100", name: adguard-primary }
   - { addr: "192.168.178.254:9100", name: adguard-secondary }
 
+# PVE exporter — Proxmox VE metrics
+pve_exporter_target: "192.168.178.110"
+pve_exporter_scrape_addr: "192.168.178.110:9221"
+
 # Grafana OIDC (PocketID)
 grafana_vault_secret_path: "kv/homelab/data/grafana"
 grafana_oidc_name: "PocketID"

--- a/roles/monitoring/templates/prometheus.yml.j2
+++ b/roles/monitoring/templates/prometheus.yml.j2
@@ -19,3 +19,20 @@ scrape_configs:
     relabel_configs:
       - source_labels: [nodename]
         target_label: instance
+
+  - job_name: "pve"
+    static_configs:
+      - targets:
+          - "{{ pve_exporter_target }}"
+    metrics_path: /pve
+    params:
+      module: [default]
+      cluster: ["1"]
+      node: ["1"]
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: "{{ pve_exporter_scrape_addr }}"

--- a/roles/pve_exporter/defaults/main.yml
+++ b/roles/pve_exporter/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+pve_exporter_version: "3.5.1"
+pve_exporter_port: 9221
+pve_exporter_venv: /opt/pve-exporter
+pve_exporter_config: /etc/pve-exporter/pve.yml
+pve_exporter_user: pve-exporter
+
+# Vault path for PVE API token
+pve_exporter_vault_path: "kv/homelab/data/pve-exporter"
+
+# PVE connection
+pve_exporter_pve_host: "localhost"
+pve_exporter_pve_port: 8006
+pve_exporter_verify_ssl: false

--- a/roles/pve_exporter/handlers/main.yml
+++ b/roles/pve_exporter/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart pve-exporter
+  ansible.builtin.systemd:
+    name: pve-exporter
+    state: restarted
+    daemon_reload: true

--- a/roles/pve_exporter/tasks/main.yml
+++ b/roles/pve_exporter/tasks/main.yml
@@ -1,0 +1,69 @@
+---
+- name: Install Python venv package
+  ansible.builtin.apt:
+    name:
+      - python3-venv
+      - python3-pip
+    state: present
+    update_cache: true
+
+- name: Create pve-exporter system user
+  ansible.builtin.user:
+    name: "{{ pve_exporter_user }}"
+    system: true
+    shell: /usr/sbin/nologin
+    create_home: false
+
+- name: Create Python virtual environment
+  ansible.builtin.command:
+    cmd: python3 -m venv {{ pve_exporter_venv }}
+    creates: "{{ pve_exporter_venv }}/bin/python"
+
+- name: Install prometheus-pve-exporter in venv
+  ansible.builtin.pip:
+    name: "prometheus-pve-exporter=={{ pve_exporter_version }}"
+    virtualenv: "{{ pve_exporter_venv }}"
+    state: present
+
+- name: Fetch PVE API credentials from Vault
+  community.hashi_vault.vault_read:
+    url: "{{ vault_addr }}"
+    path: "{{ pve_exporter_vault_path }}"
+    auth_method: approle
+    role_id: "{{ vault_role_id }}"
+    secret_id: "{{ vault_secret_id }}"
+  register: pve_vault_secret
+  delegate_to: localhost
+  become: false
+
+- name: Create config directory
+  ansible.builtin.file:
+    path: "{{ pve_exporter_config | dirname }}"
+    state: directory
+    mode: '0750'
+    owner: root
+    group: "{{ pve_exporter_user }}"
+
+- name: Deploy pve.yml config
+  ansible.builtin.template:
+    src: pve.yml.j2
+    dest: "{{ pve_exporter_config }}"
+    mode: '0640'
+    owner: root
+    group: "{{ pve_exporter_user }}"
+  notify: Restart pve-exporter
+  no_log: true
+
+- name: Deploy systemd service
+  ansible.builtin.template:
+    src: pve-exporter.service.j2
+    dest: /etc/systemd/system/pve-exporter.service
+    mode: '0644'
+  notify: Restart pve-exporter
+
+- name: Enable and start pve-exporter
+  ansible.builtin.systemd:
+    name: pve-exporter
+    state: started
+    enabled: true
+    daemon_reload: true

--- a/roles/pve_exporter/templates/pve-exporter.service.j2
+++ b/roles/pve_exporter/templates/pve-exporter.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Prometheus PVE Exporter
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User={{ pve_exporter_user }}
+Group={{ pve_exporter_user }}
+Type=simple
+ExecStart={{ pve_exporter_venv }}/bin/pve_exporter --config.file {{ pve_exporter_config }} --web.listen-address :{{ pve_exporter_port }}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/pve_exporter/templates/pve.yml.j2
+++ b/roles/pve_exporter/templates/pve.yml.j2
@@ -1,0 +1,5 @@
+default:
+  user: {{ pve_vault_secret.data.data.data.user }}
+  token_name: {{ pve_vault_secret.data.data.data.token_name }}
+  token_value: {{ pve_vault_secret.data.data.data.token_value }}
+  verify_ssl: {{ pve_exporter_verify_ssl | lower }}

--- a/vars/pve_exporter_vars.yml.example
+++ b/vars/pve_exporter_vars.yml.example
@@ -1,0 +1,15 @@
+# PVE Exporter — Proxmox API credentials for metrics collection
+# Store these in Vault at kv/homelab/pve-exporter with keys: user, token_name, token_value
+#
+# Create a dedicated API token in Proxmox:
+#   1. Datacenter → Permissions → API Tokens → Add
+#   2. User: root@pam (or a dedicated monitoring user)
+#   3. Token ID: e.g. "prometheus"
+#   4. Uncheck "Privilege Separation" for full read access
+#   5. Save the token value
+#
+# Then store in Vault:
+#   vault kv put kv/homelab/pve-exporter \
+#     user="root@pam" \
+#     token_name="prometheus" \
+#     token_value="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"


### PR DESCRIPTION
- New pve_exporter role installs prometheus-pve-exporter in a Python venv
- Fetches Proxmox API token credentials from Vault
- Runs as dedicated pve-exporter system user on port 9221
- Adds pve scrape job to Prometheus with multi-target relabeling
- Enables the "Proxmox via Prometheus" Grafana dashboard (ID 10347)