### PR TITLE
fix: arr media mount — require subdirs exist, drop chown, run as root

### DIFF
--- a/inventory/group_vars/arr_host.yml
+++ b/inventory/group_vars/arr_host.yml
@@ -1,4 +1,7 @@
 ---
 # ARR stack LXC at 192.168.178.141. Override media paths if mount differs.
 # arr_media_path: /media   # default; must be bind-mounted from Proxmox media-storage
+# Media dirs are root:root — run *arr containers as root to read/write.
+arr_uid: 0
+arr_gid: 0
 ansible_user: root

--- a/roles/arr/tasks/main.yml
+++ b/roles/arr/tasks/main.yml
@@ -35,18 +35,6 @@
     - "{{ arr_movies_path }}"
     - "{{ arr_tv_path }}"
 
-- name: Set ownership on media directories
-  ansible.builtin.file:
-    path: "{{ item }}"
-    owner: "{{ arr_uid }}"
-    group: "{{ arr_gid }}"
-    mode: '0755'
-    recurse: yes
-  loop:
-    - "{{ arr_downloads_path }}"
-    - "{{ arr_movies_path }}"
-    - "{{ arr_tv_path }}"
-
 - name: Deploy ARR stack compose file
   ansible.builtin.template:
     src: docker-compose.yml.j2


### PR DESCRIPTION
- Require downloads/movies/tv exist on media host; do not create from LXC (bind mount often read-only)
- Remove Set ownership task (chown not permitted on bind mount)
- arr_host: run *arr as root (0:0) to match root-owned media dirs