### PR TITLE
feat: proxy *arr stack behind mol.la subdomains via Caddy

### DIFF
--- a/inventory/group_vars/caddy_host.yml
+++ b/inventory/group_vars/caddy_host.yml
@@ -1,3 +1,5 @@
 ---
 # Caddy host(s) — reverse proxy + Cloudflare Tunnel
 ansible_user: root
+# *arr stack LXC IP — from inventory (override here if needed)
+arr_lxc_ip: "{{ hostvars['arr'].ansible_host }}"

--- a/roles/caddy/defaults/main.yml
+++ b/roles/caddy/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Caddy role defaults. Override arr_lxc_ip in group_vars/caddy_host.yml or vars.
+arr_lxc_ip: "192.168.178.141"

--- a/roles/caddy/templates/Caddyfile.j2
+++ b/roles/caddy/templates/Caddyfile.j2
@@ -63,7 +63,35 @@ http://grafana.mol.la, grafana.mol.la {
 # Jellyfin — media server (media.mol.la)
 http://media.mol.la, media.mol.la {
     import protected
-    reverse_proxy 192.168.178.140:8096
+    reverse_proxy {{ hostvars['jellyfin'].ansible_host }}:8096
+}
+
+# *arr stack — SABnzbd, Prowlarr, Radarr, Sonarr, Bazarr, Jellyseerr (arr LXC)
+# Backend: arr_lxc_ip from group_vars/caddy_host or role defaults
+http://sabnzbd.mol.la, sabnzbd.mol.la {
+    import protected
+    reverse_proxy {{ arr_lxc_ip }}:8080
+}
+http://prowlarr.mol.la, prowlarr.mol.la {
+    import protected
+    reverse_proxy {{ arr_lxc_ip }}:9696
+}
+http://radarr.mol.la, radarr.mol.la {
+    import protected
+    reverse_proxy {{ arr_lxc_ip }}:7878
+}
+http://sonarr.mol.la, sonarr.mol.la {
+    import protected
+    reverse_proxy {{ arr_lxc_ip }}:8989
+}
+http://bazarr.mol.la, bazarr.mol.la {
+    import protected
+    reverse_proxy {{ arr_lxc_ip }}:6767
+}
+# Jellyseerr — request/approval UI
+http://requests.mol.la, requests.mol.la {
+    import protected
+    reverse_proxy {{ arr_lxc_ip }}:5055
 }
 
 # AdGuard Primary — DNS UI


### PR DESCRIPTION
- Add reverse_proxy blocks for sabnzbd, prowlarr, radarr, sonarr, bazarr, requests (Jellyseerr)
- arr_lxc_ip from group_vars/caddy_host (inventory) and role defaults
- Add roles/caddy/defaults/main.yml; Jellyfin uses hostvars directly
- Block style matches existing (import protected, no redundant header_up)