### PR TITLE
chore: make Jellyfin (media.mol.la) public, auth via Jellyfin only

### DIFF
--- a/roles/caddy/templates/Caddyfile.j2
+++ b/roles/caddy/templates/Caddyfile.j2
@@ -60,9 +60,8 @@ http://grafana.mol.la, grafana.mol.la {
     reverse_proxy 192.168.178.124:3000
 }
 
-# Jellyfin — media server (media.mol.la)
+# Jellyfin — media server (media.mol.la), public; auth via Jellyfin users only
 http://media.mol.la, media.mol.la {
-    import protected
     reverse_proxy {{ hostvars['jellyfin'].ansible_host }}:8096
 }
 


### PR DESCRIPTION
Remove `import protected` from media.mol.la so Jellyfin is reachable without Pocket ID forward auth. Access control is Jellyfin's own user login only.