### PR TITLE
feat: arr same mount as Jellyfin, run as nobody, check-only media subdirs

### DIFF
--- a/inventory/group_vars/arr_host.yml
+++ b/inventory/group_vars/arr_host.yml
@@ -1,7 +1,6 @@
 ---
 # ARR stack LXC at 192.168.178.141. Override media paths if mount differs.
-# arr_media_path: /media   # default; must be bind-mounted from Proxmox media-storage
-# Media dirs are root:root — run *arr containers as root to read/write.
-arr_uid: 0
-arr_gid: 0
+# Unprivileged LXC: /media bind mount appears as nobody (65534) — run *arr as nobody to see/write.
+arr_uid: 65534
+arr_gid: 65534
 ansible_user: root

--- a/roles/arr/defaults/main.yml
+++ b/roles/arr/defaults/main.yml
@@ -25,10 +25,9 @@ arr_gid: 1000
 # Timezone
 arr_tz: "Etc/UTC"
 
-# Media paths (inside the LXC — bind-mounted from Proxmox)
-# The LXC should have /media bound from Proxmox (same as Jellyfin).
+# Media paths (inside the LXC — bind-mounted from Proxmox, same as Jellyfin)
+# Arr LXC mount: host /mnt/media → guest /media (see proxmox_create_lxc defaults, same as jellyfin).
 arr_media_path: /media
-# Subdirectories under /media/libraries
 arr_downloads_path: "{{ arr_media_path }}/libraries/downloads"
 arr_movies_path: "{{ arr_media_path }}/libraries/movies"
 arr_tv_path: "{{ arr_media_path }}/libraries/tv"

--- a/roles/arr/tasks/main.yml
+++ b/roles/arr/tasks/main.yml
@@ -25,15 +25,22 @@
     msg: "Media path '{{ arr_media_path }}' must exist on the LXC. Add a bind mount in Proxmox (e.g. mp0=/path/to/media-storage,{{ arr_media_path }}) and create the LXC mount point."
   when: not media_path_stat.stat.exists or not media_path_stat.stat.isdir
 
-- name: Ensure media subdirectories exist
-  ansible.builtin.file:
+- name: Check media subdirectories exist
+  ansible.builtin.stat:
     path: "{{ item }}"
-    state: directory
-    mode: '0755'
+  register: media_subdirs_stat
   loop:
     - "{{ arr_downloads_path }}"
     - "{{ arr_movies_path }}"
     - "{{ arr_tv_path }}"
+
+- name: Fail if media subdirectories are missing
+  ansible.builtin.fail:
+    msg: >-
+      Media subdirs must exist on the host before deploy (bind mount may be read-only in LXC).
+      On the Proxmox host create: {{ arr_downloads_path }}, {{ arr_movies_path }}, {{ arr_tv_path }}
+      (e.g. mkdir -p /mnt/media/libraries/{downloads,movies,tv}) then re-run.
+  when: media_subdirs_stat.results | selectattr('stat.exists', 'equalto', true) | list | length != 3
 
 - name: Deploy ARR stack compose file
   ansible.builtin.template:


### PR DESCRIPTION
- Arr LXC: same bind mount as Jellyfin (host /mnt/media → guest /media)
- arr_media_path: /media; downloads, movies, tv under /media/libraries
- arr_host: arr_uid/arr_gid 65534 so *arr can see/write mount in unprivileged LXC
- arr tasks: require media subdirs to exist (check-only), fail with hint to create on Proxmox host