### PR TITLE
fix: run *arr as root (0:0) so /movies, /tv, /downloads are writable

### DIFF
--- a/inventory/group_vars/arr_host.yml
+++ b/inventory/group_vars/arr_host.yml
@@ -1,6 +1,6 @@
 ---
 # ARR stack LXC at 192.168.178.141. Override media paths if mount differs.
-# Unprivileged LXC: /media bind mount appears as nobody (65534) — run *arr as nobody to see/write.
-arr_uid: 65534
-arr_gid: 65534
+# Run *arr as root (0:0) so /movies, /tv, /downloads are writable (mount permission quirks in unprivileged LXC).
+arr_uid: 0
+arr_gid: 0
 ansible_user: root


### PR DESCRIPTION
Fixes 'Folder /movies/ is not writable by user nobody'. Run *arr containers as root so they can write to the bind-mounted media dirs (unprivileged LXC mount permission quirks).