### PR TITLE
fix: open ufw port 9100 for monitoring host in node_exporter role

### DIFF
--- a/roles/node_exporter/tasks/main.yml
+++ b/roles/node_exporter/tasks/main.yml
@@ -10,3 +10,11 @@
     name: prometheus-node-exporter
     state: started
     enabled: true
+
+- name: Allow monitoring host to scrape node-exporter (port 9100)
+  community.general.ufw:
+    rule: allow
+    port: "9100"
+    proto: tcp
+    src: "192.168.178.124"
+  when: ansible_facts['os_family'] == 'Debian'

--- a/roles/pve_exporter/tasks/main.yml
+++ b/roles/pve_exporter/tasks/main.yml
@@ -75,9 +75,3 @@
     proto: tcp
     src: "{{ monitoring_host_ip }}"
 
-- name: Allow monitoring host to scrape node-exporter (port 9100)
-  community.general.ufw:
-    rule: allow
-    port: "9100"
-    proto: tcp
-    src: "{{ monitoring_host_ip }}"


### PR DESCRIPTION
Adds a ufw rule to allow the monitoring host (192.168.178.124) to scrape node-exporter on port 9100. Removes the duplicate rule from pve_exporter since node_exporter role now handles it for all hosts including Proxmox.