### PR TITLE
feat: add llm, dash, openclaw LXCs and fix monitoring targets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,12 @@ ansible-galaxy install -r requirements.yml
 ansible-playbook deployments/deploy_<service>.yml -vv
 ```
 
+Makefile aliases (equivalent to `./lab lxc`):
+```bash
+make create-lxc    # same as ./lab lxc create
+make destroy-lxc   # same as ./lab lxc destroy
+```
+
 `ansible.cfg` sets `become_ask_pass = True` — playbooks prompt for sudo password unless `ansible_become_pass` is set in `vars/vault_auth_vars.yml`.
 
 No test suite or linter. Validation is manual (SSH into deployed hosts, verify Docker Compose status).
@@ -70,6 +76,10 @@ vars/                    → runtime secrets/config (gitignored); *.example file
 | 192.168.178.140 | Jellyfin                          | Docker Compose |
 | 192.168.178.141 | *arr stack                        | Docker Compose |
 | 192.168.178.142 | Immich                            | Docker Compose |
+| 192.168.178.125 | LLM (Ollama + Gemma 4)            | Docker Compose |
+| 192.168.178.250 | Dash (Open WebUI + dashboards)    | Docker Compose |
+| 192.168.178.251 | OpenClaw AI agent                 | Node.js        |
+| 192.168.178.252 | Humaun                            | Docker Compose |
 | 192.168.178.253 | AdGuard Primary                   | Docker Compose |
 | 192.168.178.254 | AdGuard Secondary                 | Docker Compose |
 
@@ -103,6 +113,14 @@ Most playbooks need runtime secrets that are gitignored. Copy the `.example` fil
 10. **Open UFW port** for monitoring host scrape: allow `192.168.178.124` → port `9100` (see `roles/node_exporter`)
 11. **Caddy**: add route to `roles/caddy/templates/Caddyfile.j2`, run `./lab deploy caddy`
 
+### Ansible Galaxy Collections
+
+```
+community.proxmox, community.docker, community.hashi_vault, community.postgresql, community.mysql
+```
+
+Install before first run: `ansible-galaxy install -r requirements.yml`
+
 ### Key Conventions
 
 - Docker Compose files are templated via Jinja2 (`compose.yml.j2`) and deployed to `/opt/compose/<service>-{{ inventory_hostname }}/`
@@ -112,6 +130,7 @@ Most playbooks need runtime secrets that are gitignored. Copy the `.example` fil
 - Caddy handles all SSL termination and external access (including Cloudflare Tunnel); services listen internally only
 - Caddy uses a custom Dockerfile (in `roles/caddy/files/`) that builds the Cloudflare DNS plugin via `xcaddy`; runs in `network_mode: host`
 - Caddy Caddyfile defines a reusable `(protected)` snippet for Tinyauth forward-auth; import it with `import protected` on protected routes
+- Database roles (postgresql, mysql, mongodb) have a `create_app.yml` task file separate from `main.yml` — included by playbooks that need per-app users/databases. PostgreSQL apps also specify extensions (e.g. `vector`, `earthdistance` for Immich).
 - PostgreSQL has pgvector installed for Immich; `pg_hba.conf` is templated
 - Monitoring: Prometheus + Grafana scrape all hosts via node_exporter; add new scrape targets in `roles/monitoring/defaults/main.yml` → `prometheus_node_targets`
 - AdGuard Primary runs in host network mode (required for DHCP broadcasts); Secondary uses bridge

--- a/roles/monitoring/defaults/main.yml
+++ b/roles/monitoring/defaults/main.yml
@@ -24,6 +24,10 @@ prometheus_node_targets:
   - { addr: "192.168.178.140:9100", name: jellyfin }
   - { addr: "192.168.178.141:9100", name: arr }
   - { addr: "192.168.178.142:9100", name: immich }
+  - { addr: "192.168.178.125:9100", name: llm }
+  - { addr: "192.168.178.250:9100", name: dash }
+  - { addr: "192.168.178.251:9100", name: openclaw }
+  - { addr: "192.168.178.252:9100", name: humaun }
   - { addr: "192.168.178.253:9100", name: adguard-primary }
   - { addr: "192.168.178.254:9100", name: adguard-secondary }
 

--- a/roles/proxmox_create_lxc/defaults/main.yml
+++ b/roles/proxmox_create_lxc/defaults/main.yml
@@ -49,6 +49,14 @@ proxmox_containers:
     cores: 2
     memory: 2048
     disk: "local-lvm:20"
+  - vmid: 125
+    hostname: llm
+    ip: "192.168.178.125/24"
+    description: "Ollama LLM inference"
+    unprivileged: 1
+    cores: 4
+    memory: 16384
+    disk: "local-lvm:30"
   - vmid: 130
     hostname: postgresql
     ip: "192.168.178.130/24"
@@ -111,13 +119,27 @@ proxmox_containers:
       - id: mp0
         host_path: "{{ jellyfin_media_storage_host_path }}"
         mountpoint: /media
+  - vmid: 250
+    hostname: dash
+    ip: "192.168.178.250/24"
+    description: "My Dashboard"
+    unprivileged: 1
+    cores: 2
+    memory: 2048
+    disk: "local-lvm:10"
+  - vmid: 251
+    hostname: openclaw
+    ip: "192.168.178.251/24"
+    description: "OpenClaw AI agent (Node.js)"
+    unprivileged: 1
+    disk: "local-lvm:20"
   - vmid: 252
     hostname: humaun
     ip: "192.168.178.252/24"
     description: "LXC for Humaun"
     unprivileged: 1
     cores: 2
-    memory: 8192
+    memory: 2048
     disk: "local-lvm:20"
   - vmid: 253
     hostname: adguard-primary


### PR DESCRIPTION
Add three new LXC containers (vmid 125/250/251) for Ollama inference, Open WebUI + dashboards, and OpenClaw agent. Add missing humaun to Prometheus scrape targets. Update CLAUDE.md with galaxy collections, create_app.yml pattern, and Makefile aliases.