### PR TITLE
fix: set nameserver and searchdomain on LXC creation

### DIFF
--- a/roles/proxmox_create_lxc/defaults/main.yml
+++ b/roles/proxmox_create_lxc/defaults/main.yml
@@ -12,6 +12,8 @@ proxmox_memory: 1024
 proxmox_swap: 512
 proxmox_gw: "192.168.178.1"
 proxmox_bridge: "vmbr0"
+proxmox_nameserver: "192.168.178.253 192.168.178.254"
+proxmox_searchdomain: "mol.la"
 
 proxmox_ssh_pubkey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGPdbWBj0cioTEXSeNjotNxDol9QRGuhRTI1q3xsK4+D ansible-homelab"
 

--- a/roles/proxmox_create_lxc/tasks/main.yml
+++ b/roles/proxmox_create_lxc/tasks/main.yml
@@ -27,6 +27,8 @@
     features: "{{ item.features | default(['nesting=1']) }}"
     onboot: true
     description: "{{ item.description }}"
+    nameserver: "{{ proxmox_nameserver }}"
+    searchdomain: "{{ proxmox_searchdomain }}"
     state: present
   loop: "{{ proxmox_containers }}"
   loop_control:
@@ -48,3 +50,4 @@
   loop_control:
     label: "{{ item.hostname }}"
   no_log: true
+  ignore_errors: true


### PR DESCRIPTION
Proxmox host has Tailscale DNS which gets injected into new LXCs. Set mol.la search domain and AdGuard nameservers explicitly so new containers don't inherit Tailscale DNS and lose internet connectivity.