### PR TITLE
feat: add llm role, group_vars, and fix lxc create idempotency

### DIFF
--- a/deployments/deploy_llm.yml
+++ b/deployments/deploy_llm.yml
@@ -1,0 +1,9 @@
+---
+# Deploy Ollama LLM inference server (Docker on LXC).
+# Pulls gemma4:4b model on first deploy (~3 GB download).
+# Usage: ansible-playbook deployments/deploy_llm.yml
+- name: Deploy LLM (Ollama)
+  hosts: llm_host
+  become: true
+  roles:
+    - llm

--- a/inventory/group_vars/dash_host.yml
+++ b/inventory/group_vars/dash_host.yml
@@ -1,0 +1,2 @@
+---
+ansible_user: root

--- a/inventory/group_vars/humaun_host.yml
+++ b/inventory/group_vars/humaun_host.yml
@@ -1,0 +1,2 @@
+---
+ansible_user: root

--- a/inventory/group_vars/llm_host.yml
+++ b/inventory/group_vars/llm_host.yml
@@ -1,0 +1,2 @@
+---
+ansible_user: root

--- a/inventory/group_vars/openclaw_host.yml
+++ b/inventory/group_vars/openclaw_host.yml
@@ -1,0 +1,2 @@
+---
+ansible_user: root

--- a/roles/llm/defaults/main.yml
+++ b/roles/llm/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+ollama_image: ollama/ollama:latest
+ollama_port: 11434
+ollama_model: gemma4:4b
+ollama_tz: "Europe/Amsterdam"

--- a/roles/llm/handlers/main.yml
+++ b/roles/llm/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart Ollama
+  community.docker.docker_compose_v2:
+    project_src: "/opt/compose/ollama-{{ inventory_hostname }}"
+    state: present
+    restarted: true

--- a/roles/llm/tasks/main.yml
+++ b/roles/llm/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+- name: Ensure compose project directory exists
+  ansible.builtin.file:
+    path: "/opt/compose/ollama-{{ inventory_hostname }}"
+    state: directory
+    mode: '0755'
+
+- name: Deploy Ollama compose file
+  ansible.builtin.template:
+    src: compose.yml.j2
+    dest: "/opt/compose/ollama-{{ inventory_hostname }}/compose.yml"
+    mode: '0644'
+  notify: Restart Ollama
+
+- name: Start Ollama with Docker Compose
+  community.docker.docker_compose_v2:
+    project_src: "/opt/compose/ollama-{{ inventory_hostname }}"
+    state: present
+
+- name: Wait for Ollama API to be ready
+  ansible.builtin.uri:
+    url: "http://localhost:{{ ollama_port }}"
+    status_code: 200
+  register: ollama_ready
+  retries: 12
+  delay: 5
+  until: ollama_ready.status == 200
+
+- name: Pull {{ ollama_model }} model
+  ansible.builtin.command:
+    cmd: "docker exec ollama-{{ inventory_hostname }} ollama pull {{ ollama_model }}"
+  register: pull_result
+  changed_when: "'already up to date' not in pull_result.stdout"

--- a/roles/llm/templates/compose.yml.j2
+++ b/roles/llm/templates/compose.yml.j2
@@ -1,0 +1,14 @@
+services:
+  ollama:
+    image: {{ ollama_image }}
+    container_name: ollama-{{ inventory_hostname }}
+    restart: unless-stopped
+    ports:
+      - "{{ ollama_port }}:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    environment:
+      TZ: "{{ ollama_tz }}"
+
+volumes:
+  ollama_data:

--- a/roles/proxmox_create_lxc/tasks/main.yml
+++ b/roles/proxmox_create_lxc/tasks/main.yml
@@ -3,6 +3,18 @@
 # Requires: community.proxmox collection (ansible-galaxy collection install community.proxmox)
 # Required: proxmox_api_user; proxmox_api_token_id; proxmox_api_token_secret; proxmox_container_password
 # Skip create for privileged (unprivileged: 0) when using token auth — Proxmox requires root@pam (password) for those.
+
+- name: Get current LXC container status from Proxmox
+  ansible.builtin.command:
+    cmd: "pvesh get /nodes/{{ proxmox_node }}/lxc/{{ item.vmid }}/status/current --output-format json"
+  delegate_to: "{{ proxmox_api_host }}"
+  loop: "{{ proxmox_containers }}"
+  loop_control:
+    label: "{{ item.hostname }}"
+  register: lxc_status
+  ignore_errors: true
+  changed_when: false
+
 - name: Create LXC container on Proxmox
   community.proxmox.proxmox:
     api_host: "{{ proxmox_api_host }}"
@@ -12,28 +24,30 @@
     api_token_secret: "{{ proxmox_api_token_secret }}"
     validate_certs: "{{ proxmox_validate_certs | default(false) }}"
     node: "{{ proxmox_node }}"
-    vmid: "{{ item.vmid }}"
-    hostname: "{{ item.hostname }}"
+    vmid: "{{ item.item.vmid }}"
+    hostname: "{{ item.item.hostname }}"
     ostemplate: "{{ proxmox_ostemplate }}"
     password: "{{ proxmox_container_password }}"
     pubkey: "{{ proxmox_ssh_pubkey }}"
-    disk: "{{ item.disk | default(proxmox_disk) }}"
-    cores: "{{ item.cores | default(proxmox_cores) }}"
-    memory: "{{ item.memory | default(proxmox_memory) }}"
-    swap: "{{ item.swap | default(proxmox_swap) }}"
+    disk: "{{ item.item.disk | default(proxmox_disk) }}"
+    cores: "{{ item.item.cores | default(proxmox_cores) }}"
+    memory: "{{ item.item.memory | default(proxmox_memory) }}"
+    swap: "{{ item.item.swap | default(proxmox_swap) }}"
     netif:
-      net0: "name=eth0,bridge={{ proxmox_bridge }},gw={{ proxmox_gw }},ip={{ item.ip }}"
-    unprivileged: "{{ item.unprivileged | default(1) }}"
-    features: "{{ item.features | default(['nesting=1']) }}"
+      net0: "name=eth0,bridge={{ proxmox_bridge }},gw={{ proxmox_gw }},ip={{ item.item.ip }}"
+    unprivileged: "{{ item.item.unprivileged | default(1) }}"
+    features: "{{ item.item.features | default(['nesting=1']) }}"
     onboot: true
-    description: "{{ item.description }}"
+    description: "{{ item.item.description }}"
     nameserver: "{{ proxmox_nameserver }}"
     searchdomain: "{{ proxmox_searchdomain }}"
     state: present
-  loop: "{{ proxmox_containers }}"
+  loop: "{{ lxc_status.results }}"
   loop_control:
-    label: "{{ item.hostname }}"
-  when: (item.unprivileged | default(1) | int) != 0 or (proxmox_api_password is defined and proxmox_api_password | default('') | length > 0)
+    label: "{{ item.item.hostname }}"
+  when:
+    - (item.item.unprivileged | default(1) | int) != 0 or (proxmox_api_password is defined and proxmox_api_password | default('') | length > 0)
+    - item.rc != 0
   register: lxc_create_result
 
 - name: Start newly created LXC containers
@@ -44,9 +58,9 @@
     api_token_id: "{{ proxmox_api_token_id }}"
     api_token_secret: "{{ proxmox_api_token_secret }}"
     validate_certs: "{{ proxmox_validate_certs | default(false) }}"
-    vmid: "{{ item.item.vmid }}"
+    vmid: "{{ item.item.item.vmid }}"
     state: started
   loop: "{{ lxc_create_result.results }}"
   loop_control:
-    label: "{{ item.item.hostname }}"
-  when: item.changed
+    label: "{{ item.item.item.hostname }}"
+  when: item.changed | default(false)


### PR DESCRIPTION
- Add Ollama role: deploys Docker Compose, pulls gemma4:4b, exposes API on port 11434 to all LXCs in 192.168.178.0/24
- Add group_vars for llm, dash, openclaw, humaun (ansible_user: root)
- Fix proxmox_create_lxc: use pvesh to check container existence before create/start so already-running containers are never restarted