### PR TITLE
feat: migrate jellyseerr to seerr, bump pocket-id, pin image vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ These services use explicit version vars in `roles/<service>/defaults/main.yml` 
 | `vault`        | `vault_version`        |
 | `mongodb`      | `mongodb_version`      |
 | `pve-exporter` | `pve_exporter_version` |
+| `pocketid`     | `pocketid_image`       |
+| `tinyauth`     | `tinyauth_image`       |
 
 ## Architecture
 
@@ -73,10 +75,10 @@ vars/                    → runtime secrets/config (gitignored); *.example file
 | 192.168.178.131 | MariaDB                           | systemd apt    |
 | 192.168.178.132 | Redis                             | systemd apt    |
 | 192.168.178.133 | MongoDB                           | systemd apt    |
+| 192.168.178.125 | LLM (Ollama + Gemma 4)            | Docker Compose |
 | 192.168.178.140 | Jellyfin                          | Docker Compose |
 | 192.168.178.141 | *arr stack                        | Docker Compose |
 | 192.168.178.142 | Immich                            | Docker Compose |
-| 192.168.178.125 | LLM (Ollama + Gemma 4)            | Docker Compose |
 | 192.168.178.250 | Dash (Open WebUI + dashboards)    | Docker Compose |
 | 192.168.178.251 | OpenClaw AI agent                 | Node.js        |
 | 192.168.178.252 | Humaun                            | Docker Compose |

--- a/roles/arr/defaults/main.yml
+++ b/roles/arr/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# *arr stack — SABnzbd, Prowlarr, Radarr, Sonarr, Bazarr, Jellyseerr
+# *arr stack — SABnzbd, Prowlarr, Radarr, Sonarr, Bazarr, Seerr
 # Deploys in a single Docker Compose stack inside an LXC.
 
 # Docker images (linuxserver.io)
@@ -8,7 +8,7 @@ arr_prowlarr_image: lscr.io/linuxserver/prowlarr:latest
 arr_radarr_image: lscr.io/linuxserver/radarr:latest
 arr_sonarr_image: lscr.io/linuxserver/sonarr:latest
 arr_bazarr_image: lscr.io/linuxserver/bazarr:latest
-arr_jellyseerr_image: fallenbagel/jellyseerr:latest
+arr_seerr_image: ghcr.io/seerr-team/seerr:latest
 
 # Ports
 arr_sabnzbd_port: 8080
@@ -16,7 +16,7 @@ arr_prowlarr_port: 9696
 arr_radarr_port: 7878
 arr_sonarr_port: 8989
 arr_bazarr_port: 6767
-arr_jellyseerr_port: 5055
+arr_seerr_port: 5055
 
 # User/Group IDs (PUID/PGID) — adjust to match media ownership on the host
 arr_uid: 1000

--- a/roles/arr/templates/docker-compose.yml.j2
+++ b/roles/arr/templates/docker-compose.yml.j2
@@ -1,4 +1,4 @@
-# *arr stack — SABnzbd, Prowlarr, Radarr, Sonarr, Bazarr, Jellyseerr
+# *arr stack — SABnzbd, Prowlarr, Radarr, Sonarr, Bazarr, Seerr
 # Media directories must be bind-mounted into the LXC from Proxmox (same as Jellyfin).
 services:
   # SABnzbd - Usenet downloader
@@ -85,20 +85,19 @@ services:
       PGID: "{{ arr_gid }}"
       TZ: "{{ arr_tz }}"
 
-  # Jellyseerr - Request frontend for Jellyfin
+  # Seerr - Media request frontend (migrated from Jellyseerr)
   # Access at :5055 — connect to Jellyfin (https://media.mol.la), Radarr (http://radarr:7878),
   # Sonarr (http://sonarr:8989) during setup for requests to auto-add
-  jellyseerr:
-    image: fallenbagel/jellyseerr:latest
-    container_name: jellyseerr-{{ inventory_hostname }}
+  seerr:
+    image: {{ arr_seerr_image }}
+    container_name: seerr-{{ inventory_hostname }}
     restart: unless-stopped
+    init: true
     ports:
       - "5055:5055"
     volumes:
-      - {{ arr_config_path }}/jellyseerr:/app/config
+      - {{ arr_config_path }}/seerr:/seerr
     environment:
-      PUID: "{{ arr_uid }}"
-      PGID: "{{ arr_gid }}"
       TZ: "{{ arr_tz }}"
 
 # Shared network for inter-container communication

--- a/roles/caddy/templates/Caddyfile.j2
+++ b/roles/caddy/templates/Caddyfile.j2
@@ -87,8 +87,8 @@ http://bazarr.mol.la, bazarr.mol.la {
     import protected
     reverse_proxy {{ arr_lxc_ip }}:6767
 }
-# Jellyseerr — request/approval UI
-http://requests.mol.la, requests.mol.la {
+# Seerr — media request/approval UI
+http://seerr.mol.la, seerr.mol.la {
     import protected
     reverse_proxy {{ arr_lxc_ip }}:5055
 }

--- a/roles/pocketid/defaults/main.yml
+++ b/roles/pocketid/defaults/main.yml
@@ -1,3 +1,6 @@
 ---
 # Vault path for PocketID secrets (pocketid_encryption_key, tinyauth_pocketid_client_id, tinyauth_pocketid_client_secret)
 pocketid_vault_secret_path: "kv/homelab/data/pocketid"
+
+pocketid_image: "ghcr.io/pocket-id/pocket-id:v2.6.2"
+tinyauth_image: "ghcr.io/steveiliop56/tinyauth:v4"

--- a/roles/pocketid/templates/compose.yml.j2
+++ b/roles/pocketid/templates/compose.yml.j2
@@ -1,6 +1,6 @@
 services:
   tinyauth:
-    image: ghcr.io/steveiliop56/tinyauth:v4
+    image: {{ tinyauth_image }}
     container_name: tinyauth-{{ inventory_hostname }}
     restart: unless-stopped
     # We map to the internal Docker IP or specific host IP for Caddy
@@ -24,7 +24,7 @@ services:
       TRUSTED_PROXIES: "192.168.178.121,127.0.0.1,::1"
 
   pocketid:
-    image: ghcr.io/pocket-id/pocket-id:v2
+    image: {{ pocketid_image }}
     container_name: pocketid-{{ inventory_hostname }}
     restart: unless-stopped
     ports:


### PR DESCRIPTION
- Replace jellyseerr (fallenbagel) with seerr (seerr-team) — drop-in replacement with automatic config migration on first start
- Add init: true and fix volume path (/seerr) per migration guide
- Rename Caddy route requests.mol.la → seerr.mol.la
- Bump pocket-id v2 → v2.6.2; keep tinyauth at v4 (v5 has breaking env changes)
- Move pocketid/tinyauth image tags to defaults vars for easier upgrades
- Update CLAUDE.md pinned-version table and fix IP ordering