### PR TITLE
fix: pass vault_auth_vars to caddy deploy and add vault seeding guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ Most playbooks need runtime secrets that are gitignored. Copy the `.example` fil
 
 | Playbook          | Required vars flags                                             |
 |-------------------|-----------------------------------------------------------------|
-| deploy_caddy      | `-e "@vars/caddy_vars.yml"`                                     |
+| deploy_caddy      | `-e "@vars/caddy_vars.yml" -e "@vars/vault_auth_vars.yml"`      |
 | deploy_pocketid   | `-e "@vars/pocketid_vars.yml"`                                  |
 | configure_vault   | `-e "vault_token=<root>" -e "@vars/vault_config_vars.yml"`      |
 | deploy_monitoring | `-e "@vars/vault_auth_vars.yml"`                                |

--- a/README.md
+++ b/README.md
@@ -131,33 +131,7 @@ vault_secret_id: "<from output>"
 
 ### 5. Seed secrets in Vault
 
-Before deploying services, store their secrets:
-
-```bash
-# Caddy
-vault kv put kv/homelab/data/caddy \
-  cloudflare_api_token="..." cloudflare_tunnel_token="..." caddy_cloudflare_email="..."
-
-# PocketID
-vault kv put kv/homelab/data/pocketid \
-  pocketid_encryption_key="$(openssl rand -base64 32)" \
-  tinyauth_pocketid_client_id="..." tinyauth_pocketid_client_secret="..." \
-  pocketid_maxmind_license_key=""
-
-# Databases
-vault kv put kv/homelab/data/postgresql immich="<password>"
-vault kv put kv/homelab/data/redis password="<password>"
-vault kv put kv/homelab/data/mysql root="<password>"
-vault kv put kv/homelab/data/mongodb admin="<password>"
-
-# Grafana OIDC
-vault kv put kv/homelab/data/grafana client_id="..." client_secret="..."
-
-# PVE Exporter
-vault kv put kv/homelab/data/pve_exporter user="..." password="..."
-```
-
-See each `vars/*.example` file for the full list of expected keys.
+See **[docs/seeding-vault-secrets.md](docs/seeding-vault-secrets.md)** for the full guide including how to obtain each token/credential and curl commands for every service.
 
 ### 6. Core services
 

--- a/docs/seeding-vault-secrets.md
+++ b/docs/seeding-vault-secrets.md
@@ -1,0 +1,205 @@
+# Seeding Vault Secrets
+
+All service secrets live in Vault under `kv/homelab/data/<service>`. Seed them once after bootstrapping Vault. Vault must be initialized, unsealed, and AppRole configured before running any service deploys.
+
+Substitute `<root_token>` with your Vault root token. All `curl` commands can be run from the Ansible LXC (`192.168.178.120`).
+
+---
+
+## Helper
+
+All examples use curl. If you prefer the Vault UI: **Secrets → kv/homelab → Create secret** with the path and keys below.
+
+```bash
+VAULT=http://192.168.178.123:8200
+TOKEN=<root_token>
+```
+
+---
+
+## Caddy
+
+**Where to get values:**
+
+- `cloudflare_api_token` — [dash.cloudflare.com](https://dash.cloudflare.com) → My Profile → API Tokens → Create Token → *Edit zone DNS* template → scope to `mol.la`
+- `cloudflare_tunnel_token` — Zero Trust → Networks → Tunnels → your tunnel → Configure → Docker command → copy the `--token` value
+- `caddy_cloudflare_email` — your Cloudflare account email
+
+```bash
+curl -s -X POST $VAULT/v1/kv/homelab/data/caddy \
+  -H "X-Vault-Token: $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "data": {
+      "cloudflare_api_token": "YOUR_CF_API_TOKEN",
+      "cloudflare_tunnel_token": "YOUR_TUNNEL_TOKEN",
+      "caddy_cloudflare_email": "you@example.com"
+    }
+  }'
+```
+
+---
+
+## PocketID + Tinyauth
+
+**Where to get values:**
+
+- `pocketid_encryption_key` — generate randomly (see below)
+- `tinyauth_pocketid_client_id` / `tinyauth_pocketid_client_secret` — create OIDC client at `https://id.mol.la/settings/admin/oidc-clients`, callback URL: `https://id.mol.la/api/oauth/callback/pocketid`
+- `pocketid_maxmind_license_key` — optional, leave empty if not using GeoIP
+
+```bash
+curl -s -X POST $VAULT/v1/kv/homelab/data/pocketid \
+  -H "X-Vault-Token: $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"data\": {
+      \"pocketid_encryption_key\": \"$(openssl rand -base64 32)\",
+      \"tinyauth_pocketid_client_id\": \"YOUR_CLIENT_ID\",
+      \"tinyauth_pocketid_client_secret\": \"YOUR_CLIENT_SECRET\",
+      \"pocketid_maxmind_license_key\": \"\"
+    }
+  }"
+```
+
+---
+
+## PostgreSQL
+
+```bash
+curl -s -X POST $VAULT/v1/kv/homelab/data/postgresql \
+  -H "X-Vault-Token: $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "data": {
+      "homelab_password": "STRONG_PASSWORD",
+      "immich_password": "STRONG_PASSWORD"
+    }
+  }'
+```
+
+---
+
+## Redis
+
+```bash
+curl -s -X POST $VAULT/v1/kv/homelab/data/redis \
+  -H "X-Vault-Token: $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "data": {
+      "password": "STRONG_PASSWORD"
+    }
+  }'
+```
+
+---
+
+## MySQL
+
+```bash
+curl -s -X POST $VAULT/v1/kv/homelab/data/mysql \
+  -H "X-Vault-Token: $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "data": {
+      "mysql_password": "STRONG_PASSWORD"
+    }
+  }'
+```
+
+---
+
+## MongoDB
+
+```bash
+curl -s -X POST $VAULT/v1/kv/homelab/data/mongodb \
+  -H "X-Vault-Token: $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "data": {
+      "admin_password": "STRONG_PASSWORD",
+      "homelab": "STRONG_PASSWORD"
+    }
+  }'
+```
+
+---
+
+## Grafana OIDC
+
+**Where to get values:** Create OIDC client at `https://id.mol.la/settings/admin/oidc-clients`, callback URL: `https://grafana.mol.la/login/generic_oauth`
+
+```bash
+curl -s -X POST $VAULT/v1/kv/homelab/data/grafana \
+  -H "X-Vault-Token: $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "data": {
+      "client_id": "YOUR_CLIENT_ID",
+      "client_secret": "YOUR_CLIENT_SECRET"
+    }
+  }'
+```
+
+---
+
+## Immich OIDC
+
+**Where to get values:** Create OIDC client at `https://id.mol.la/settings/admin/oidc-clients`, redirect URIs:
+- `https://photos.mol.la/auth/login`
+- `https://photos.mol.la/user-settings`
+- `app.immich:///oauth-callback`
+
+```bash
+curl -s -X POST $VAULT/v1/kv/homelab/data/immich_oidc \
+  -H "X-Vault-Token: $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "data": {
+      "client_id": "YOUR_CLIENT_ID",
+      "client_secret": "YOUR_CLIENT_SECRET"
+    }
+  }'
+```
+
+---
+
+## PVE Exporter
+
+**Where to get values:** Proxmox UI → Datacenter → Permissions → API Tokens → Add. Use `root@pam`, token ID `prometheus`, uncheck Privilege Separation.
+
+```bash
+curl -s -X POST $VAULT/v1/kv/homelab/data/pve-exporter \
+  -H "X-Vault-Token: $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "data": {
+      "user": "root@pam",
+      "token_name": "prometheus",
+      "token_value": "YOUR_TOKEN_VALUE"
+    }
+  }'
+```
+
+---
+
+## Vault OIDC (for Vault UI login via PocketID)
+
+**Where to get values:** Create OIDC client at `https://id.mol.la/settings/admin/oidc-clients`, callback URL: `https://vault.mol.la/ui/vault/auth/oidc/oidc/callback`
+
+These go in `vars/vault_config_vars.yml` (not Vault), used during `./lab vault-config`:
+
+```yaml
+vault_oidc_client_id: "YOUR_CLIENT_ID"
+vault_oidc_client_secret: "YOUR_CLIENT_SECRET"
+```
+
+---
+
+## Verify a secret was stored correctly
+
+```bash
+curl -s -H "X-Vault-Token: $TOKEN" \
+  $VAULT/v1/kv/homelab/data/<service> | python3 -m json.tool
+```

--- a/lab
+++ b/lab
@@ -152,7 +152,9 @@ cmd_deploy() {
   case "$service" in
     adguard)       _run ansible-playbook "$DEPLOYMENTS_DIR/deploy_adguard.yml" ;;
     caddy)         _require_vars caddy_vars.yml
-                   _run ansible-playbook "$DEPLOYMENTS_DIR/deploy_caddy.yml" -e "@$VARS_DIR/caddy_vars.yml" ;;
+                   _require_vars vault_auth_vars.yml
+                   _run ansible-playbook "$DEPLOYMENTS_DIR/deploy_caddy.yml" \
+                     -e "@$VARS_DIR/caddy_vars.yml" -e "@$VARS_DIR/vault_auth_vars.yml" ;;
     pocketid)      _require_vars pocketid_vars.yml
                    _run ansible-playbook "$DEPLOYMENTS_DIR/deploy_pocketid.yml" -e "@$VARS_DIR/pocketid_vars.yml" ;;
     vault)         _run ansible-playbook "$DEPLOYMENTS_DIR/deploy_vault.yml" ;;


### PR DESCRIPTION
caddy deploy was missing vault_auth_vars.yml, causing vault_addr undefined error at runtime. Also extracts vault secret seeding into a dedicated doc with curl commands and instructions for obtaining each credential.