### PR TITLE
feat: add OCI A1 Flex AI inference infrastructure

### DIFF
--- a/.github/workflows/oci-ai-inference.yml
+++ b/.github/workflows/oci-ai-inference.yml
@@ -1,0 +1,122 @@
+name: OCI AI Inference
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "cloud/oci/ai-inference/terraform/**"
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Terraform action"
+        required: true
+        default: plan
+        type: choice
+        options:
+          - plan
+          - apply
+          - destroy
+
+permissions:
+  contents: read
+
+env:
+  TF_VERSION: "1.15.1"
+  TF_WORKING_DIR: cloud/oci/ai-inference/terraform
+  # OCI S3-compat backend
+  TF_BACKEND_BUCKET: ${{ vars.OCI_STATE_BUCKET }}
+  TF_BACKEND_KEY: "oci-ai-inference/terraform.tfstate"
+  TF_BACKEND_REGION: ${{ vars.OCI_REGION }}
+  TF_BACKEND_ENDPOINT: "https://${{ vars.OCI_STATE_NAMESPACE }}.compat.objectstorage.${{ vars.OCI_REGION }}.oraclecloud.com"
+
+jobs:
+  terraform:
+    name: Terraform ${{ github.event.inputs.action || 'plan' }}
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Write OCI API private key
+        run: |
+          mkdir -p ~/.oci
+          echo "${{ secrets.OCI_PRIVATE_KEY_CONTENT }}" > ~/.oci/oci_api_key.pem
+          chmod 600 ~/.oci/oci_api_key.pem
+
+      - name: Terraform Init
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: |
+          terraform init \
+            -backend-config="bucket=${TF_BACKEND_BUCKET}" \
+            -backend-config="key=${TF_BACKEND_KEY}" \
+            -backend-config="region=${TF_BACKEND_REGION}" \
+            -backend-config="endpoint=${TF_BACKEND_ENDPOINT}" \
+            -backend-config="access_key=${{ secrets.OCI_STATE_ACCESS_KEY }}" \
+            -backend-config="secret_key=${{ secrets.OCI_STATE_SECRET_KEY }}" \
+            -backend-config="skip_region_validation=true" \
+            -backend-config="skip_credentials_validation=true" \
+            -backend-config="skip_metadata_api_check=true" \
+            -backend-config="skip_requesting_account_id=true" \
+            -backend-config="force_path_style=true" \
+            -backend-config="use_lockfile=true"
+
+      - name: Terraform Plan
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        env:
+          TF_VAR_tenancy_ocid: ${{ secrets.OCI_TENANCY_OCID }}
+          TF_VAR_user_ocid: ${{ secrets.OCI_USER_OCID }}
+          TF_VAR_fingerprint: ${{ secrets.OCI_FINGERPRINT }}
+          TF_VAR_private_key_content: ${{ secrets.OCI_PRIVATE_KEY_CONTENT }}
+          TF_VAR_region: ${{ vars.OCI_REGION }}
+          TF_VAR_compartment_ocid: ${{ secrets.OCI_COMPARTMENT_OCID }}
+          TF_VAR_availability_domain: ${{ vars.OCI_AVAILABILITY_DOMAIN }}
+          TF_VAR_ssh_public_key: ${{ secrets.OCI_SSH_PUBLIC_KEY }}
+          TF_VAR_tailscale_auth_key: ${{ secrets.TAILSCALE_AUTH_KEY_OCI }}
+        run: terraform plan -out=tfplan -input=false
+
+      - name: Upload plan artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tfplan
+          path: ${{ env.TF_WORKING_DIR }}/tfplan
+          retention-days: 1
+
+      - name: Terraform Apply
+        if: >
+          github.event.inputs.action == 'apply' &&
+          github.ref == 'refs/heads/main'
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        env:
+          TF_VAR_tenancy_ocid: ${{ secrets.OCI_TENANCY_OCID }}
+          TF_VAR_user_ocid: ${{ secrets.OCI_USER_OCID }}
+          TF_VAR_fingerprint: ${{ secrets.OCI_FINGERPRINT }}
+          TF_VAR_private_key_content: ${{ secrets.OCI_PRIVATE_KEY_CONTENT }}
+          TF_VAR_region: ${{ vars.OCI_REGION }}
+          TF_VAR_compartment_ocid: ${{ secrets.OCI_COMPARTMENT_OCID }}
+          TF_VAR_availability_domain: ${{ vars.OCI_AVAILABILITY_DOMAIN }}
+          TF_VAR_ssh_public_key: ${{ secrets.OCI_SSH_PUBLIC_KEY }}
+          TF_VAR_tailscale_auth_key: ${{ secrets.TAILSCALE_AUTH_KEY_OCI }}
+        run: terraform apply -auto-approve -input=false tfplan
+
+      - name: Terraform Destroy
+        if: >
+          github.event.inputs.action == 'destroy' &&
+          github.ref == 'refs/heads/main'
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        env:
+          TF_VAR_tenancy_ocid: ${{ secrets.OCI_TENANCY_OCID }}
+          TF_VAR_user_ocid: ${{ secrets.OCI_USER_OCID }}
+          TF_VAR_fingerprint: ${{ secrets.OCI_FINGERPRINT }}
+          TF_VAR_private_key_content: ${{ secrets.OCI_PRIVATE_KEY_CONTENT }}
+          TF_VAR_region: ${{ vars.OCI_REGION }}
+          TF_VAR_compartment_ocid: ${{ secrets.OCI_COMPARTMENT_OCID }}
+          TF_VAR_availability_domain: ${{ vars.OCI_AVAILABILITY_DOMAIN }}
+          TF_VAR_ssh_public_key: ${{ secrets.OCI_SSH_PUBLIC_KEY }}
+          TF_VAR_tailscale_auth_key: ${{ secrets.TAILSCALE_AUTH_KEY_OCI }}
+        run: terraform destroy -auto-approve -input=false

--- a/.github/workflows/oci-bootstrap.yml
+++ b/.github/workflows/oci-bootstrap.yml
@@ -1,0 +1,109 @@
+name: OCI Bootstrap
+
+on:
+  workflow_dispatch:
+    inputs:
+      bucket_name:
+        description: "State bucket name"
+        required: true
+        default: "homelab-tfstate"
+      secret_key_display_name:
+        description: "Customer Secret Key display name"
+        required: true
+        default: "github-actions-tfstate"
+
+permissions:
+  contents: read
+
+jobs:
+  bootstrap:
+    name: Create state bucket + secret key
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install OCI CLI
+        run: |
+          pip install oci-cli --quiet
+
+      - name: Configure OCI CLI
+        run: |
+          mkdir -p ~/.oci
+          echo "${{ secrets.OCI_PRIVATE_KEY_CONTENT }}" > ~/.oci/oci_api_key.pem
+          chmod 600 ~/.oci/oci_api_key.pem
+          cat > ~/.oci/config << EOF
+          [DEFAULT]
+          user=${{ secrets.OCI_USER_OCID }}
+          fingerprint=${{ secrets.OCI_FINGERPRINT }}
+          tenancy=${{ secrets.OCI_TENANCY_OCID }}
+          region=${{ vars.OCI_REGION }}
+          key_file=~/.oci/oci_api_key.pem
+          EOF
+          chmod 600 ~/.oci/config
+
+      - name: Create state bucket (idempotent)
+        run: |
+          BUCKET="${{ github.event.inputs.bucket_name }}"
+          COMPARTMENT="${{ secrets.OCI_COMPARTMENT_OCID }}"
+
+          # Check if bucket exists
+          if oci os bucket get --bucket-name "$BUCKET" --namespace "${{ vars.OCI_STATE_NAMESPACE }}" > /dev/null 2>&1; then
+            echo "Bucket $BUCKET already exists — skipping creation."
+          else
+            echo "Creating bucket $BUCKET..."
+            oci os bucket create \
+              --compartment-id "$COMPARTMENT" \
+              --name "$BUCKET" \
+              --namespace "${{ vars.OCI_STATE_NAMESPACE }}" \
+              --versioning Enabled \
+              --storage-tier Standard
+            echo "Bucket created."
+          fi
+
+      - name: Create Customer Secret Key
+        id: secret_key
+        run: |
+          USER_OCID="${{ secrets.OCI_USER_OCID }}"
+          DISPLAY_NAME="${{ github.event.inputs.secret_key_display_name }}"
+
+          echo "Creating Customer Secret Key '$DISPLAY_NAME'..."
+          RESULT=$(oci iam customer-secret-key create \
+            --user-id "$USER_OCID" \
+            --display-name "$DISPLAY_NAME")
+
+          # Extract values — key secret is only shown once at creation
+          KEY_ID=$(echo "$RESULT" | jq -r '.data.id')
+          KEY_SECRET=$(echo "$RESULT" | jq -r '.data.key')
+
+          # Mask values in logs
+          echo "::add-mask::$KEY_ID"
+          echo "::add-mask::$KEY_SECRET"
+
+          echo "key_id=$KEY_ID" >> "$GITHUB_OUTPUT"
+          echo "key_secret=$KEY_SECRET" >> "$GITHUB_OUTPUT"
+          echo "Customer Secret Key created (ID masked)."
+
+      - name: Set GHA secrets via GitHub CLI
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          REPO="${{ github.repository }}"
+          gh secret set OCI_STATE_ACCESS_KEY \
+            --body "${{ steps.secret_key.outputs.key_id }}" \
+            --repo "$REPO"
+          gh secret set OCI_STATE_SECRET_KEY \
+            --body "${{ steps.secret_key.outputs.key_secret }}" \
+            --repo "$REPO"
+          echo "OCI_STATE_ACCESS_KEY and OCI_STATE_SECRET_KEY set in repository secrets."
+
+      - name: Summary
+        run: |
+          echo "### Bootstrap complete" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Resource | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| State bucket \`${{ github.event.inputs.bucket_name }}\` | ✅ Ready |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Customer Secret Key \`${{ github.event.inputs.secret_key_display_name }}\` | ✅ Created |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`OCI_STATE_ACCESS_KEY\` GHA secret | ✅ Set |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`OCI_STATE_SECRET_KEY\` GHA secret | ✅ Set |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Run **OCI AI Inference → apply** to provision the instance." >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,17 @@ venv/
 .DS_Store
 Thumbs.db
 
+# Terraform
+*.tfvars
+!*.tfvars.example
+backend.hcl
+!backend.hcl.example
+.terraform/
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup
+*.tfplan
+
 # Logs and temp
 *.log
 *.tmp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,15 +143,16 @@ Install before first run: `ansible-galaxy install -r requirements.yml`
 
 All secrets live under `kv/homelab/data/<service>` (kv-v2 engine):
 
-| Path                          | Keys                                  |
-|-------------------------------|---------------------------------------|
-| `kv/homelab/data/postgresql`  | `homelab_password`, `immich_password` |
-| `kv/homelab/data/redis`       | `password`                            |
-| `kv/homelab/data/mysql`       | `mysql_password`                      |
-| `kv/homelab/data/grafana`     | `client_id`, `client_secret` (OIDC)   |
-| `kv/homelab/data/immich_oidc` | `client_id`, `client_secret` (OIDC)   |
-| `kv/homelab/data/pve-exporter`| `user`, `token_name`, `token_value`   |
-| `kv/homelab/data/caddy`       | `cloudflare_api_token`, `cloudflare_tunnel_token`, `caddy_cloudflare_email` |
-| `kv/homelab/data/pocketid`    | `pocketid_encryption_key`, `tinyauth_pocketid_client_id`, `tinyauth_pocketid_client_secret`, `pocketid_maxmind_license_key` |
+| Path                           | Keys                                                                                                                        |
+|--------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| `kv/homelab/data/postgresql`   | `homelab_password`, `immich_password`                                                                                       |
+| `kv/homelab/data/redis`        | `password`                                                                                                                  |
+| `kv/homelab/data/mysql`        | `mysql_password`                                                                                                            |
+| `kv/homelab/data/grafana`      | `client_id`, `client_secret` (OIDC)                                                                                         |
+| `kv/homelab/data/immich_oidc`  | `client_id`, `client_secret` (OIDC)                                                                                         |
+| `kv/homelab/data/pve-exporter` | `user`, `token_name`, `token_value`                                                                                         |
+| `kv/homelab/data/caddy`        | `cloudflare_api_token`, `cloudflare_tunnel_token`, `cloudflare_account_email`                                               |
+| `kv/homelab/data/pocketid`     | `pocketid_encryption_key`, `tinyauth_pocketid_client_id`, `tinyauth_pocketid_client_secret`, `pocketid_maxmind_license_key` |
+| `kv/homelab/data/tailscale`    | `auth_key`                                                                                                                  |
 
 Vault reads always use `delegate_to: localhost` + `become: false` (runs on Ansible control, not target host).

--- a/cloud/oci/ai-inference/README.md
+++ b/cloud/oci/ai-inference/README.md
@@ -1,0 +1,226 @@
+# OCI A1 Flex — AI Inference
+
+OCI Always-Free Ampere A1 Flex instance running **Ollama + Qwen3.6:27b** for homelab agent use (NanoClaw/Timothy). No public exposure — access via Tailscale only. Infrastructure managed via GitHub Actions.
+
+## Hardware
+
+| Resource | Value |
+|---|---|
+| Shape | VM.Standard.A1.Flex |
+| OCPU | 4 (Arm Neoverse N1) |
+| RAM | 24 GB |
+| Boot volume | 100 GB |
+| Cost | $0 (Always-Free) |
+
+## Model
+
+**`qwen3.6:27b`** (default Q4 quant, ~17 GB)
+
+| Item | Size |
+|---|---|
+| Model weights | ~17 GB |
+| KV cache + runtime | ~4 GB |
+| OS + Tailscale | ~1.5 GB |
+| **Headroom** | **~1.5 GB** |
+
+Expected throughput: **3–6 tok/s** on 4× Neoverse N1 (CPU-only, bandwidth-bound). Acceptable for agentic non-streaming calls.
+
+> `qwen3.6:35b` (24 GB) is off the table — zero headroom after OS overhead.
+
+---
+
+## Prerequisites
+
+- OCI account with A1 Always-Free quota available
+- OCI CLI installed and configured (`~/.oci/config`)
+- Tailscale account with an ephemeral auth key (`tag:homelab`, pre-authorized)
+
+---
+
+## One-Time Bootstrap
+
+Bootstrap creates the S3-compatible state bucket and injects the Customer Secret Key back into GHA secrets — fully automated via GitHub Actions. Only the initial OCI credentials need manual entry.
+
+### 1. Get OCI identifiers (OCI Console or CLI)
+
+```bash
+oci iam tenancy get --query 'data.id' --raw-output          # tenancy OCID
+oci iam user list --query 'data[0].id' --raw-output          # user OCID
+oci os ns get --query 'data' --raw-output                    # object storage namespace
+oci iam availability-domain list --query 'data[].name'       # availability domains
+```
+
+### 2. Set initial GitHub secrets and variables manually
+
+These are set once and never change. The bootstrap workflow sets the remaining two secrets automatically.
+
+#### Repository secrets (`Settings → Secrets → Actions`):
+
+| Secret | Value |
+|---|---|
+| `OCI_TENANCY_OCID` | Tenancy OCID |
+| `OCI_USER_OCID` | User OCID |
+| `OCI_FINGERPRINT` | API key fingerprint |
+| `OCI_PRIVATE_KEY_CONTENT` | Full PEM content of `~/.oci/oci_api_key.pem` |
+| `OCI_COMPARTMENT_OCID` | Compartment OCID |
+| `OCI_SSH_PUBLIC_KEY` | `cat ~/.ssh/id_ed25519.pub` |
+| `TAILSCALE_AUTH_KEY_OCI` | Tailscale ephemeral auth key (`tag:homelab`, pre-authorized) |
+| `GH_PAT` | GitHub classic PAT with `repo` scope (used by bootstrap to write secrets) |
+
+#### Repository variables (`Settings → Variables → Actions`):
+
+| Variable | Value |
+|---|---|
+| `OCI_REGION` | e.g. `eu-frankfurt-1` |
+| `OCI_AVAILABILITY_DOMAIN` | e.g. `XoEF:EU-FRANKFURT-1-AD-1` |
+| `OCI_STATE_NAMESPACE` | Object storage namespace from step 1 |
+| `OCI_STATE_BUCKET` | `homelab-tfstate` |
+
+### 3. Run the bootstrap workflow
+
+**Actions → OCI Bootstrap → Run workflow**
+
+This creates the `homelab-tfstate` bucket (idempotent) and a Customer Secret Key, then automatically sets `OCI_STATE_ACCESS_KEY` and `OCI_STATE_SECRET_KEY` as repository secrets. Run once — or re-run if the secret key is rotated.
+
+---
+
+## Deployment (GitHub Actions)
+
+Trigger from **Actions → OCI AI Inference → Run workflow**:
+
+- **plan** — always runs on push to `main` touching `terraform/**`; also manual
+- **apply** — manual only, deploys the instance
+- **destroy** — manual only, tears down everything
+
+> `destroy` is manual-only and requires `main` branch. No accidental teardown from PRs.
+
+---
+
+## Post-Provisioning
+
+### Wait for cloud-init (~15–25 min)
+
+cloud-init installs Tailscale, Ollama, pulls `qwen3.6:27b` (~17 GB), and hardens UFW.
+
+```bash
+# SSH in during bootstrap via the public IP shown in Terraform output
+ssh ubuntu@<public_ip>
+sudo tail -f /var/log/cloud-init-output.log
+sudo journalctl -u ollama-pull-model.service -f
+```
+
+### Verify
+
+```bash
+# From any Tailscale-connected host
+curl http://oci-ai-inference:11434/api/tags | jq '.models[].name'
+```
+
+Should return `qwen3.6:27b`.
+
+### Run Ansible
+
+```bash
+ansible-playbook cloud/oci/ai-inference/ansible/playbooks/deploy_oci_ollama.yml \
+  -e "@vars/vault_auth_vars.yml"
+```
+
+---
+
+## Local Terraform (optional)
+
+```bash
+cd cloud/oci/ai-inference/terraform
+cp terraform.tfvars.example terraform.tfvars   # fill in values
+cp backend.hcl.example backend.hcl             # fill in values
+terraform init -backend-config=backend.hcl
+terraform plan
+```
+
+---
+
+## Connecting from Timothy / NanoClaw
+
+Set the Ollama base URL to:
+
+```
+http://oci-ai-inference:11434
+```
+
+The Tailscale hostname resolves on all tailnet nodes. No port forwarding, no public IP.
+
+```bash
+curl http://oci-ai-inference:11434/api/generate \
+  -d '{"model":"qwen3.6:27b","prompt":"ping","stream":false}'
+```
+
+---
+
+## Monitoring
+
+node-exporter on port 9100. UFW allows scraping from `192.168.178.124` (Prometheus) only.
+
+OCI node registered as Prometheus scrape target via `inventory/host_vars/monitoring.yml`. Requires monitoring LXC enrolled in Tailscale with MagicDNS. If MagicDNS unavailable, replace hostname with static Tailscale IP in `monitoring.yml`.
+
+Activate:
+```bash
+./lab deploy monitoring
+```
+
+Suggested Grafana alerts:
+- `node_memory_MemAvailable_bytes{instance="oci-ai-inference"} < 512000000` — OOM risk
+- `node_load1{instance="oci-ai-inference"} > 4` — sustained overload
+
+---
+
+## Updating the Model
+
+```bash
+ssh ubuntu@oci-ai-inference
+ollama pull qwen3.6:27b   # update in place
+ollama rm <old-model>     # free disk if switching
+```
+
+Or change `ollama_model` in `roles/oci_ollama/defaults/main.yml` and re-run Ansible.
+
+---
+
+## Rollback / Destroy
+
+Trigger **Actions → OCI AI Inference → Run workflow → destroy**.
+
+> **Warning:** Permanently deletes the instance and boot volume. Model weights re-downloaded on next apply (~17 GB).
+
+---
+
+## Cost & Quota Safety
+
+- OCI Always-Free A1: **4 OCPU + 24 GB RAM total** — this instance uses the full allocation.
+- Boot volume: 100 GB of 200 GB free block storage.
+- Object Storage state: negligible size, Always-Free Standard tier (20 GB free).
+- Outbound bandwidth: 10 TB/month free.
+- No paid resources provisioned. If OCI introduces charges, trigger destroy immediately.
+
+---
+
+## File Layout
+
+```
+cloud/oci/ai-inference/
+├── terraform/
+│   ├── versions.tf               # provider, Terraform version, S3 backend
+│   ├── main.tf                   # VCN, subnet, security list, instance
+│   ├── variables.tf
+│   ├── outputs.tf
+│   ├── terraform.tfvars.example  # local use template
+│   ├── backend.hcl.example       # local backend config template
+│   └── files/
+│       └── cloud-init.yml.tftpl  # bootstrap: Tailscale + Ollama + UFW
+└── ansible/
+    └── playbooks/
+        └── deploy_oci_ollama.yml # role resolved from top-level roles/oci_ollama/
+
+.github/workflows/
+├── oci-bootstrap.yml             # one-time: create state bucket + set GHA secrets
+└── oci-ai-inference.yml          # plan / apply / destroy
+```

--- a/cloud/oci/ai-inference/ansible/playbooks/deploy_oci_ollama.yml
+++ b/cloud/oci/ai-inference/ansible/playbooks/deploy_oci_ollama.yml
@@ -1,0 +1,9 @@
+---
+# Deploy and configure Ollama on OCI A1 Flex instance.
+# Requires Tailscale connectivity to the target host.
+# Usage: ansible-playbook cloud/oci/ai-inference/ansible/playbooks/deploy_oci_ollama.yml
+- name: Configure OCI AI inference node
+  hosts: oci_host
+  become: true
+  roles:
+    - role: oci_ollama

--- a/cloud/oci/ai-inference/terraform/backend.hcl.example
+++ b/cloud/oci/ai-inference/terraform/backend.hcl.example
@@ -1,0 +1,23 @@
+# Copy to backend.hcl and fill in values for local terraform init.
+# In CI these are passed via -backend-config flags in the workflow.
+# backend.hcl is gitignored.
+
+bucket   = "homelab-tfstate"
+key      = "oci-ai-inference/terraform.tfstate"
+region   = "eu-frankfurt-1"
+
+# OCI Object Storage S3-compat endpoint.
+# Format: https://<namespace>.compat.objectstorage.<region>.oraclecloud.com
+endpoint = "https://<namespace>.compat.objectstorage.eu-frankfurt-1.oraclecloud.com"
+
+# Customer Secret Key (IAM → User → Customer Secret Keys)
+access_key = "YOUR_CUSTOMER_SECRET_KEY_ID"
+secret_key = "YOUR_CUSTOMER_SECRET_KEY_SECRET"
+
+# Required for OCI S3-compat backend
+skip_region_validation      = true
+skip_credentials_validation = true
+skip_metadata_api_check     = true
+skip_requesting_account_id  = true
+force_path_style            = true
+use_lockfile                = true

--- a/cloud/oci/ai-inference/terraform/files/cloud-init.yml.tftpl
+++ b/cloud/oci/ai-inference/terraform/files/cloud-init.yml.tftpl
@@ -1,0 +1,133 @@
+#cloud-config
+# Bootstraps: Tailscale, Ollama, ${ollama_model}, node-exporter, UFW hardening.
+# Runs once on first boot. Subsequent config managed by Ansible.
+
+hostname: ${hostname}
+manage_etc_hosts: true
+
+package_update: true
+package_upgrade: true
+packages:
+  - curl
+  - ufw
+  - iptables-persistent
+  - prometheus-node-exporter
+  - ca-certificates
+  - gnupg
+
+write_files:
+  - path: /etc/ollama/environment
+    permissions: "0600"
+    owner: root:root
+    content: |
+      # Bind to all interfaces — UFW restricts access to tailscale0 only.
+      OLLAMA_HOST=0.0.0.0:11434
+      OLLAMA_MODELS=/var/lib/ollama/models
+      OLLAMA_MAX_LOADED_MODELS=1
+      OLLAMA_KEEP_ALIVE=10m
+      OLLAMA_NUM_PARALLEL=1
+
+  - path: /etc/systemd/system/ollama.service
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=Ollama Service
+      After=network-online.target
+      Wants=network-online.target
+
+      [Service]
+      User=ollama
+      Group=ollama
+      EnvironmentFile=/etc/ollama/environment
+      ExecStart=/usr/local/bin/ollama serve
+      Restart=always
+      RestartSec=3
+      StandardOutput=journal
+      StandardError=journal
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - path: /usr/local/bin/pull-ollama-model.sh
+    permissions: "0755"
+    content: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      MODEL="${ollama_model}"
+      echo "[pull-model] Waiting for Ollama API..."
+      for i in $(seq 1 30); do
+        if curl -sf http://127.0.0.1:11434/ > /dev/null 2>&1; then
+          break
+        fi
+        sleep 5
+      done
+      echo "[pull-model] Pulling $MODEL..."
+      /usr/local/bin/ollama pull "$MODEL"
+      echo "[pull-model] Done."
+
+  - path: /etc/systemd/system/ollama-pull-model.service
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=Pull Ollama model on first boot
+      After=ollama.service network-online.target
+      Wants=ollama.service network-online.target
+      ConditionPathExists=!/var/lib/ollama/.model-pulled
+
+      [Service]
+      Type=oneshot
+      User=ollama
+      Environment=HOME=/var/lib/ollama
+      ExecStart=/usr/local/bin/pull-ollama-model.sh
+      ExecStartPost=/bin/touch /var/lib/ollama/.model-pulled
+      RemainAfterExit=yes
+
+      [Install]
+      WantedBy=multi-user.target
+
+runcmd:
+  # ── Tailscale ──────────────────────────────────────────────────────────────
+  - curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/noble.noarmor.gpg | tee /usr/share/keyrings/tailscale-archive-keyring.gpg > /dev/null
+  - curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/noble.tailscale-keyring.list | tee /etc/apt/sources.list.d/tailscale.list
+  - apt-get update -qq
+  - apt-get install -y tailscale
+  - systemctl enable --now tailscaled
+  - tailscale up --authkey="${tailscale_auth_key}" --hostname="${hostname}" --advertise-tags="tag:homelab" --accept-dns=false
+
+  # ── Ollama ─────────────────────────────────────────────────────────────────
+  # Download the official ARM64 binary directly (avoids pipe-to-shell).
+  - curl -fsSL https://github.com/ollama/ollama/releases/latest/download/ollama-linux-arm64 -o /usr/local/bin/ollama
+  - chmod +x /usr/local/bin/ollama
+  # Create ollama system user and model storage directory
+  - useradd -r -s /bin/false -m -d /var/lib/ollama ollama 2>/dev/null || true
+  - mkdir -p /var/lib/ollama/models /etc/ollama
+  - chown -R ollama:ollama /var/lib/ollama
+  # /etc/ollama/environment was written above; fix ownership now that user exists
+  - chown root:ollama /etc/ollama/environment
+  - systemctl daemon-reload
+  - systemctl enable --now ollama
+  - systemctl enable ollama-pull-model.service
+  - systemctl start ollama-pull-model.service
+
+  # ── node-exporter ──────────────────────────────────────────────────────────
+  - systemctl enable --now prometheus-node-exporter
+
+  # ── UFW ────────────────────────────────────────────────────────────────────
+  # OCI security list is the outer firewall; UFW is defence-in-depth.
+  # Ollama (11434) and node-exporter (9100) are reachable via Tailscale only.
+  - ufw default deny incoming
+  - ufw default allow outgoing
+  # Allow all traffic on the Tailscale interface (covers 11434, 9100, SSH via Tailscale)
+  - ufw allow in on tailscale0 to any
+  # Allow Tailscale WireGuard handshake and DERP relay on the public interface
+  - ufw allow 41641/udp comment 'Tailscale WireGuard'
+  - ufw allow 443/tcp comment 'Tailscale DERP relay'
+  - ufw --force enable
+
+  # ── Flush OCI default iptables rules ───────────────────────────────────────
+  # OCI Ubuntu images ship with permissive iptables ACCEPT rules that would
+  # bypass UFW. Flush them AFTER UFW is enabled so there is no open window.
+  # iptables-persistent (installed above) ensures UFW rules survive reboots.
+  - iptables -F INPUT
+  - iptables -F FORWARD
+  - netfilter-persistent save

--- a/cloud/oci/ai-inference/terraform/main.tf
+++ b/cloud/oci/ai-inference/terraform/main.tf
@@ -1,0 +1,133 @@
+locals {
+  cloud_init = base64encode(templatefile("${path.module}/files/cloud-init.yml.tftpl", {
+    tailscale_auth_key = var.tailscale_auth_key
+    ollama_model       = var.ollama_model
+    hostname           = var.instance_display_name
+  }))
+}
+
+# ── Network ────────────────────────────────────────────────────────────────────
+
+resource "oci_core_vcn" "ai_inference" {
+  compartment_id = var.compartment_ocid
+  display_name   = "${var.instance_display_name}-vcn"
+  cidr_blocks    = [var.vcn_cidr]
+  dns_label      = "aiinference"
+}
+
+resource "oci_core_internet_gateway" "igw" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.ai_inference.id
+  display_name   = "${var.instance_display_name}-igw"
+  enabled        = true
+}
+
+resource "oci_core_route_table" "public" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.ai_inference.id
+  display_name   = "${var.instance_display_name}-rt"
+
+  route_rules {
+    destination       = "0.0.0.0/0"
+    network_entity_id = oci_core_internet_gateway.igw.id
+  }
+}
+
+# Minimal ingress: Tailscale direct UDP + HTTPS for Tailscale DERP fallback.
+# SSH (22) intentionally omitted — access via Tailscale only post-bootstrap.
+resource "oci_core_security_list" "ai_inference" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.ai_inference.id
+  display_name   = "${var.instance_display_name}-sl"
+
+  # Allow all egress (required for Tailscale, Ollama model pull, apt)
+  egress_security_rules {
+    destination = "0.0.0.0/0"
+    protocol    = "all"
+    stateless   = false
+  }
+
+  # Tailscale direct WireGuard
+  ingress_security_rules {
+    protocol  = "17" # UDP
+    source    = "0.0.0.0/0"
+    stateless = false
+    udp_options {
+      min = 41641
+      max = 41641
+    }
+  }
+
+  # HTTPS for Tailscale DERP relay fallback
+  ingress_security_rules {
+    protocol  = "6" # TCP
+    source    = "0.0.0.0/0"
+    stateless = false
+    tcp_options {
+      min = 443
+      max = 443
+    }
+  }
+}
+
+resource "oci_core_subnet" "public" {
+  compartment_id    = var.compartment_ocid
+  vcn_id            = oci_core_vcn.ai_inference.id
+  cidr_block        = var.subnet_cidr
+  display_name      = "${var.instance_display_name}-subnet"
+  dns_label         = "pub"
+  route_table_id    = oci_core_route_table.public.id
+  security_list_ids = [oci_core_security_list.ai_inference.id]
+
+  # Public subnet — instance gets ephemeral public IP for egress during bootstrap.
+  # After Tailscale connects the public IP is unused.
+  prohibit_public_ip_on_vnic = false
+}
+
+# ── Compute ────────────────────────────────────────────────────────────────────
+
+# Canonical Ubuntu 24.04 LTS for aarch64 — query latest image.
+# OCI Always-Free A1 requires aarch64 image.
+data "oci_core_images" "ubuntu_arm" {
+  compartment_id           = var.compartment_ocid
+  operating_system         = "Canonical Ubuntu"
+  operating_system_version = "24.04"
+  shape                    = "VM.Standard.A1.Flex"
+  sort_by                  = "TIMECREATED"
+  sort_order               = "DESC"
+}
+
+resource "oci_core_instance" "ai_inference" {
+  compartment_id      = var.compartment_ocid
+  availability_domain = var.availability_domain
+  display_name        = var.instance_display_name
+  shape               = "VM.Standard.A1.Flex"
+
+  shape_config {
+    # 4 OCPU + 24 GB = full Always-Free A1 allocation
+    ocpus         = 4
+    memory_in_gbs = 24
+  }
+
+  source_details {
+    source_type             = "image"
+    source_id               = data.oci_core_images.ubuntu_arm.images[0].id
+    boot_volume_size_in_gbs = var.boot_volume_size_gb
+  }
+
+  create_vnic_details {
+    subnet_id        = oci_core_subnet.public.id
+    assign_public_ip = true
+    hostname_label   = var.instance_display_name
+  }
+
+  metadata = {
+    ssh_authorized_keys = var.ssh_public_key
+    user_data           = local.cloud_init
+  }
+
+  # Prevent accidental destroy of the model storage
+  lifecycle {
+    ignore_changes = [source_details[0].source_id]
+  }
+}

--- a/cloud/oci/ai-inference/terraform/outputs.tf
+++ b/cloud/oci/ai-inference/terraform/outputs.tf
@@ -1,0 +1,19 @@
+output "instance_id" {
+  description = "OCID of the compute instance"
+  value       = oci_core_instance.ai_inference.id
+}
+
+output "public_ip" {
+  description = "Ephemeral public IP (for bootstrap only; use Tailscale IP after first boot)"
+  value       = oci_core_instance.ai_inference.public_ip
+}
+
+output "tailscale_hostname" {
+  description = "Hostname registered in Tailscale"
+  value       = var.instance_display_name
+}
+
+output "ollama_endpoint_tailscale" {
+  description = "Ollama API endpoint reachable over Tailscale"
+  value       = "http://${var.instance_display_name}:11434"
+}

--- a/cloud/oci/ai-inference/terraform/terraform.tfvars.example
+++ b/cloud/oci/ai-inference/terraform/terraform.tfvars.example
@@ -1,0 +1,25 @@
+# Copy to terraform.tfvars and fill in values.
+# terraform.tfvars is gitignored — never commit it.
+
+tenancy_ocid     = "ocid1.tenancy.oc1..example"
+user_ocid        = "ocid1.user.oc1..example"
+fingerprint      = "aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99"
+private_key_path = "~/.oci/oci_api_key.pem"
+region           = "eu-frankfurt-1"
+
+compartment_ocid    = "ocid1.compartment.oc1..example"
+availability_domain = "XoEF:EU-FRANKFURT-1-AD-1"
+
+# cat ~/.ssh/id_ed25519.pub
+ssh_public_key = "ssh-ed25519 AAAA... user@host"
+
+# Generate at: https://login.tailscale.com/admin/settings/keys
+# Use ephemeral + pre-approved + tag:homelab
+tailscale_auth_key = "tskey-auth-..."
+
+instance_display_name = "oci-ai-inference"
+boot_volume_size_gb   = 100
+ollama_model          = "qwen3.6:27b"
+
+vcn_cidr    = "10.10.0.0/16"
+subnet_cidr = "10.10.0.0/24"

--- a/cloud/oci/ai-inference/terraform/variables.tf
+++ b/cloud/oci/ai-inference/terraform/variables.tf
@@ -1,0 +1,83 @@
+variable "tenancy_ocid" {
+  type        = string
+  description = "OCI tenancy OCID"
+}
+
+variable "user_ocid" {
+  type        = string
+  description = "OCI user OCID"
+}
+
+variable "fingerprint" {
+  type        = string
+  description = "API key fingerprint"
+}
+
+variable "private_key_path" {
+  type        = string
+  description = "Path to OCI API private key PEM file (local use). Leave empty in CI."
+  default     = ""
+}
+
+variable "private_key_content" {
+  type        = string
+  sensitive   = true
+  description = "OCI API private key PEM content (CI use). Leave empty when using private_key_path."
+  default     = ""
+}
+
+variable "region" {
+  type        = string
+  description = "OCI region (e.g. eu-frankfurt-1)"
+}
+
+variable "compartment_ocid" {
+  type        = string
+  description = "Compartment OCID to deploy resources into"
+}
+
+variable "availability_domain" {
+  type        = string
+  description = "Availability domain name (e.g. get from: oci iam availability-domain list)"
+}
+
+variable "ssh_public_key" {
+  type        = string
+  description = "SSH public key content for initial bootstrap access"
+}
+
+variable "tailscale_auth_key" {
+  type        = string
+  sensitive   = true
+  description = "Tailscale ephemeral auth key (generate at tailscale.com/admin/settings/keys)"
+}
+
+variable "instance_display_name" {
+  type        = string
+  description = "Display name for the OCI instance"
+  default     = "oci-ai-inference"
+}
+
+variable "boot_volume_size_gb" {
+  type        = number
+  description = "Boot volume size in GB (free tier allows up to 200 GB total block storage)"
+  default     = 100
+}
+
+variable "ollama_model" {
+  type        = string
+  description = "Ollama model tag to pull on first boot (see https://ollama.com/library/qwen3)"
+  default     = "qwen3.6:27b"
+}
+
+variable "vcn_cidr" {
+  type        = string
+  description = "CIDR block for the VCN"
+  default     = "10.10.0.0/16"
+}
+
+variable "subnet_cidr" {
+  type        = string
+  description = "CIDR block for the public subnet"
+  default     = "10.10.0.0/24"
+}

--- a/cloud/oci/ai-inference/terraform/versions.tf
+++ b/cloud/oci/ai-inference/terraform/versions.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">= 1.15.1"
+
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = "~> 6.0"
+    }
+  }
+
+  # OCI Object Storage (S3-compatible) — Always-Free Standard tier.
+  # Bootstrap the bucket before first apply — see README.
+  backend "s3" {
+    # All backend config passed via -backend-config in CI or backend.hcl locally.
+    # Do not hardcode values here — region/bucket differ per operator.
+  }
+}
+
+# When running locally, set private_key_path and leave private_key empty.
+# In CI, private_key is populated from GHA secret; private_key_path is ignored.
+provider "oci" {
+  tenancy_ocid     = var.tenancy_ocid
+  user_ocid        = var.user_ocid
+  fingerprint      = var.fingerprint
+  private_key_path = var.private_key_path != "" ? var.private_key_path : null
+  private_key      = var.private_key_content != "" ? var.private_key_content : null
+  region           = var.region
+}

--- a/deployments/deploy_tailscale.yml
+++ b/deployments/deploy_tailscale.yml
@@ -1,0 +1,12 @@
+---
+# Install and connect Tailscale on one or more hosts.
+# Skips hosts already connected. Safe to run repeatedly.
+#
+# Usage:
+#   ansible-playbook deployments/deploy_tailscale.yml -e "@vars/vault_auth_vars.yml" --limit monitoring
+#   ansible-playbook deployments/deploy_tailscale.yml -e "@vars/vault_auth_vars.yml" --limit monitoring,caddy
+- name: Deploy Tailscale
+  hosts: "{{ target_hosts | default('all') }}"
+  become: true
+  roles:
+    - tailscale

--- a/docs/seeding-vault-secrets.md
+++ b/docs/seeding-vault-secrets.md
@@ -23,7 +23,7 @@ TOKEN=<root_token>
 
 - `cloudflare_api_token` — [dash.cloudflare.com](https://dash.cloudflare.com) → My Profile → API Tokens → Create Token → *Edit zone DNS* template → scope to `mol.la`
 - `cloudflare_tunnel_token` — Zero Trust → Networks → Tunnels → your tunnel → Configure → Docker command → copy the `--token` value
-- `caddy_cloudflare_email` — your Cloudflare account email
+- `cloudflare_account_email` — your Cloudflare account email
 
 ```bash
 curl -s -X POST $VAULT/v1/kv/homelab/data/caddy \
@@ -33,7 +33,7 @@ curl -s -X POST $VAULT/v1/kv/homelab/data/caddy \
     "data": {
       "cloudflare_api_token": "YOUR_CF_API_TOKEN",
       "cloudflare_tunnel_token": "YOUR_TUNNEL_TOKEN",
-      "caddy_cloudflare_email": "you@example.com"
+      "cloudflare_account_email": "you@example.com"
     }
   }'
 ```

--- a/inventory/group_vars/oci_host.yml
+++ b/inventory/group_vars/oci_host.yml
@@ -1,0 +1,6 @@
+---
+# OCI A1 Flex AI inference node.
+# Connects via Tailscale hostname — not a LAN IP like other homelab hosts.
+# The instance uses 'ubuntu' (not 'root') as the default user on Ubuntu 24.04.
+ansible_user: ubuntu
+ansible_python_interpreter: /usr/bin/python3

--- a/inventory/host_vars/monitoring.yml
+++ b/inventory/host_vars/monitoring.yml
@@ -1,0 +1,7 @@
+---
+# Extra Prometheus node targets not in proxmox_containers.
+# Requires the Prometheus host to resolve these hostnames via Tailscale MagicDNS,
+# or replace with static Tailscale IPs (100.x.x.x) if MagicDNS is unavailable.
+prometheus_extra_node_targets:
+  - addr: "oci-ai-inference:9100"
+    name: oci-ai-inference

--- a/inventory/hosts
+++ b/inventory/hosts
@@ -76,7 +76,12 @@ timothy ansible_host=192.168.178.251
 [humaun_host]
 humaun ansible_host=192.168.178.252
 
-# --- Children (groups) ---
+# OCI A1 Flex — AI inference (Tailscale hostname, not LAN IP)
+# Intentionally excluded from [all_nodes]: OCI nodes are not in proxmox_containers
+# and are not scraped by the auto-derived node_exporter targets. Prometheus scrape
+# config is deployed separately via the oci_ollama Ansible role.
+[oci_host]
+oci-ai-inference ansible_host=oci-ai-inference
 
 [core:children]
 ansible_host

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,3 +5,4 @@ collections:
   - name: community.hashi_vault
   - name: community.postgresql
   - name: community.mysql
+  - name: community.general

--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -16,7 +16,7 @@
   ansible.builtin.set_fact:
     cloudflare_api_token: "{{ caddy_vault_secret.data.data.data.cloudflare_api_token }}"
     cloudflare_tunnel_token: "{{ caddy_vault_secret.data.data.data.cloudflare_tunnel_token }}"
-    caddy_cloudflare_email: "{{ caddy_vault_secret.data.data.data.caddy_cloudflare_email | default('') }}"
+    cloudflare_account_email: "{{ caddy_vault_secret.data.data.data.cloudflare_account_email | default('') }}"
   no_log: true
 
 - name: Ensure compose project directory exists

--- a/roles/caddy/templates/compose.yml.j2
+++ b/roles/caddy/templates/compose.yml.j2
@@ -15,8 +15,8 @@ services:
       - ./config/Caddyfile:/etc/caddy/Caddyfile:ro
     environment:
       CLOUDFLARE_API_TOKEN: "{{ cloudflare_api_token }}"
-{% if caddy_cloudflare_email is defined and caddy_cloudflare_email %}
-      CLOUDFLARE_EMAIL: "{{ caddy_cloudflare_email }}"
+{% if cloudflare_account_email is defined and cloudflare_account_email %}
+      CLOUDFLARE_EMAIL: "{{ cloudflare_account_email }}"
 {% endif %}
   tunnel:
     image: cloudflare/cloudflared:latest

--- a/roles/monitoring/defaults/main.yml
+++ b/roles/monitoring/defaults/main.yml
@@ -12,6 +12,10 @@ prometheus_scrape_jobs:
 prometheus_node_exporter_port: 9100
 proxmox_host_ip: "192.168.178.110"
 
+# Extra node targets not in proxmox_containers (e.g. OCI, VPS).
+# Each entry: { addr: "<host>:<port>", name: "<label>" }
+prometheus_extra_node_targets: []
+
 prometheus_immich_targets:
   - { addr: "{{ prometheus_immich_host | default('192.168.178.142') }}:8081", name: "immich-api" }
   - { addr: "{{ prometheus_immich_host | default('192.168.178.142') }}:8082", name: "immich-microservices" }

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -29,6 +29,11 @@
   loop_control:
     label: "{{ item.hostname }}"
 
+- name: Append extra node targets (non-Proxmox hosts)
+  ansible.builtin.set_fact:
+    prometheus_node_targets: "{{ prometheus_node_targets + prometheus_extra_node_targets }}"
+  when: prometheus_extra_node_targets | length > 0
+
 - name: Deploy prometheus.yml
   ansible.builtin.template:
     src: prometheus.yml.j2

--- a/roles/oci_ollama/defaults/main.yml
+++ b/roles/oci_ollama/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+ollama_model: "qwen3.6:27b"
+ollama_port: 11434
+ollama_keep_alive: "10m"
+ollama_max_loaded_models: 1
+ollama_num_parallel: 1
+ollama_models_dir: "/var/lib/ollama/models"
+
+# Prometheus monitoring host IP (matches homelab inventory)
+prometheus_host: "192.168.178.124"
+
+# Tailscale hostname registered at provisioning time
+oci_hostname: "oci-ai-inference"

--- a/roles/oci_ollama/handlers/main.yml
+++ b/roles/oci_ollama/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart Ollama
+  ansible.builtin.systemd:
+    name: ollama
+    state: restarted
+    daemon_reload: true

--- a/roles/oci_ollama/tasks/main.yml
+++ b/roles/oci_ollama/tasks/main.yml
@@ -1,0 +1,54 @@
+---
+- name: Ensure Ollama environment file is current
+  ansible.builtin.copy:
+    dest: /etc/ollama/environment
+    owner: root
+    group: ollama
+    mode: "0600"
+    content: |
+      # Bind to all interfaces — UFW restricts access to tailscale0 only.
+      OLLAMA_HOST=0.0.0.0:{{ ollama_port }}
+      OLLAMA_MODELS={{ ollama_models_dir }}
+      OLLAMA_MAX_LOADED_MODELS={{ ollama_max_loaded_models }}
+      OLLAMA_KEEP_ALIVE={{ ollama_keep_alive }}
+      OLLAMA_NUM_PARALLEL={{ ollama_num_parallel }}
+  notify: Restart Ollama
+
+- name: Ensure Ollama service is running and enabled
+  ansible.builtin.systemd:
+    name: ollama
+    state: started
+    enabled: true
+
+- name: Wait for Ollama API to be ready
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ ollama_port }}/"
+    status_code: 200
+  register: ollama_ready
+  retries: 12
+  delay: 5
+  until: ollama_ready.status == 200
+
+- name: Pull {{ ollama_model }} (idempotent)
+  ansible.builtin.command:
+    cmd: ollama pull {{ ollama_model }}
+  become: true
+  become_user: ollama
+  environment:
+    HOME: /var/lib/ollama
+  register: pull_result
+  changed_when: "'already up to date' not in pull_result.stdout"
+
+- name: Allow Prometheus to scrape node-exporter
+  community.general.ufw:
+    rule: allow
+    port: "9100"
+    proto: tcp
+    src: "{{ prometheus_host }}"
+
+- name: Ensure prometheus-node-exporter is running and enabled
+  ansible.builtin.systemd:
+    name: prometheus-node-exporter
+    state: started
+    enabled: true
+

--- a/roles/tailscale/defaults/main.yml
+++ b/roles/tailscale/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+tailscale_vault_secret_path: "kv/homelab/data/tailscale"
+tailscale_args: "--accept-dns=false"
+tailscale_tags: "tag:homelab"

--- a/roles/tailscale/handlers/main.yml
+++ b/roles/tailscale/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Confirm Tailscale connected
+  ansible.builtin.command: tailscale status
+  changed_when: false

--- a/roles/tailscale/tasks/main.yml
+++ b/roles/tailscale/tasks/main.yml
@@ -1,0 +1,64 @@
+---
+- name: Fetch Tailscale auth key from Vault
+  community.hashi_vault.vault_read:
+    url: "{{ vault_addr }}"
+    path: "{{ tailscale_vault_secret_path }}"
+    auth_method: approle
+    role_id: "{{ vault_role_id }}"
+    secret_id: "{{ vault_secret_id }}"
+  register: tailscale_vault_secret
+  delegate_to: localhost
+  become: false
+  no_log: true
+
+- name: Set Tailscale auth key
+  ansible.builtin.set_fact:
+    tailscale_auth_key: "{{ tailscale_vault_secret.data.data.data.auth_key }}"
+  no_log: true
+
+- name: Install Tailscale apt signing key
+  ansible.builtin.get_url:
+    url: https://pkgs.tailscale.com/stable/ubuntu/noble.noarmor.gpg
+    dest: /usr/share/keyrings/tailscale-archive-keyring.gpg
+    mode: "0644"
+
+- name: Add Tailscale apt repository
+  ansible.builtin.copy:
+    dest: /etc/apt/sources.list.d/tailscale.list
+    mode: "0644"
+    content: |
+      deb [signed-by=/usr/share/keyrings/tailscale-archive-keyring.gpg] https://pkgs.tailscale.com/stable/ubuntu noble main
+
+- name: Install Tailscale
+  ansible.builtin.apt:
+    name: tailscale
+    state: present
+    update_cache: true
+
+- name: Enable and start tailscaled
+  ansible.builtin.systemd:
+    name: tailscaled
+    state: started
+    enabled: true
+
+- name: Check if already connected to Tailscale
+  ansible.builtin.command: tailscale status --json
+  register: tailscale_status_raw
+  changed_when: false
+  no_log: true
+
+- name: Parse Tailscale connection state
+  ansible.builtin.set_fact:
+    tailscale_connected: "{{ (tailscale_status_raw.stdout | from_json).BackendState == 'Running' }}"
+  no_log: true
+
+- name: Connect to Tailscale
+  ansible.builtin.command: >
+    tailscale up
+    --authkey={{ tailscale_auth_key }}
+    --hostname={{ inventory_hostname }}
+    --advertise-tags={{ tailscale_tags }}
+    {{ tailscale_args }}
+  when: not tailscale_connected
+  no_log: true
+  notify: Confirm Tailscale connected


### PR DESCRIPTION
## Summary

- Terraform provisions VM.Standard.A1.Flex (4 OCPU / 24 GB RAM) on OCI Always-Free, running Ollama with `qwen3.6:27b` via Tailscale-only access
- OCI Object Storage S3-compat backend for Terraform state (Always-Free)
- GHA workflows: `oci-bootstrap` (one-time bucket + Customer Secret Key) and `oci-ai-inference` (plan/apply/destroy)
- Ansible roles: `oci_ollama` (Ollama setup, UFW, node-exporter) and `tailscale` (Vault-backed auth key, idempotent)
- Monitoring: `prometheus_extra_node_targets` extension point for non-Proxmox hosts; OCI node wired into existing Prometheus stack
- Caddy: rename `cloudflare_account_email` Ansible var to match Vault key

## Deploy order after merge

1. **Actions → OCI Bootstrap → Run workflow** — creates state bucket, auto-sets `OCI_STATE_ACCESS_KEY` + `OCI_STATE_SECRET_KEY`
2. **Actions → OCI AI Inference → apply** — provisions the VM (~15–25 min cloud-init)
3. `ansible-playbook cloud/oci/ai-inference/ansible/playbooks/deploy_oci_ollama.yml -e "@vars/vault_auth_vars.yml"`
4. `ansible-playbook deployments/deploy_tailscale.yml -e "@vars/vault_auth_vars.yml" --limit monitoring`
5. `./lab deploy monitoring`
