### PR TITLE
fix: make oci-ai-inference workflow manual-only, fix endpoint param

### DIFF
--- a/.github/workflows/oci-ai-inference.yml
+++ b/.github/workflows/oci-ai-inference.yml
@@ -1,10 +1,6 @@
 name: OCI AI Inference
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "cloud/oci/ai-inference/terraform/**"
   workflow_dispatch:
     inputs:
       action:
@@ -56,7 +52,7 @@ jobs:
             -backend-config="bucket=${TF_BACKEND_BUCKET}" \
             -backend-config="key=${TF_BACKEND_KEY}" \
             -backend-config="region=${TF_BACKEND_REGION}" \
-            -backend-config="endpoint=${TF_BACKEND_ENDPOINT}" \
+            -backend-config="endpoints={s3=\"${TF_BACKEND_ENDPOINT}\"}" \
             -backend-config="access_key=${{ secrets.OCI_STATE_ACCESS_KEY }}" \
             -backend-config="secret_key=${{ secrets.OCI_STATE_SECRET_KEY }}" \
             -backend-config="skip_region_validation=true" \

--- a/cloud/oci/ai-inference/terraform/backend.hcl.example
+++ b/cloud/oci/ai-inference/terraform/backend.hcl.example
@@ -8,7 +8,7 @@ region   = "eu-frankfurt-1"
 
 # OCI Object Storage S3-compat endpoint.
 # Format: https://<namespace>.compat.objectstorage.<region>.oraclecloud.com
-endpoint = "https://<namespace>.compat.objectstorage.eu-frankfurt-1.oraclecloud.com"
+endpoints = { s3 = "https://<namespace>.compat.objectstorage.eu-frankfurt-1.oraclecloud.com" }
 
 # Customer Secret Key (IAM → User → Customer Secret Keys)
 access_key = "YOUR_CUSTOMER_SECRET_KEY_ID"


### PR DESCRIPTION
## Summary

- Remove push trigger from `oci-ai-inference` workflow — plan was firing on merge before bootstrap sets `OCI_STATE_ACCESS_KEY`/`OCI_STATE_SECRET_KEY`, causing "No valid credential sources found" error
- Fix deprecated `endpoint` → `endpoints.s3` for Terraform 1.15 S3 backend (was warning, now correct)

## After merge

Run bootstrap first: **Actions → OCI Bootstrap → Run workflow**
Then: **Actions → OCI AI Inference → Run workflow → plan**
