### PR TITLE
fix: OCI S3 backend compat + A1 capacity retry loop

### DIFF
--- a/.github/workflows/oci-ai-inference.yml
+++ b/.github/workflows/oci-ai-inference.yml
@@ -59,7 +59,8 @@ jobs:
             -backend-config="skip_credentials_validation=true" \
             -backend-config="skip_metadata_api_check=true" \
             -backend-config="skip_requesting_account_id=true" \
-            -backend-config="use_path_style=true"
+            -backend-config="use_path_style=true" \
+            -backend-config="skip_s3_checksum=true"
 
       - name: Terraform Plan
         working-directory: ${{ env.TF_WORKING_DIR }}

--- a/.github/workflows/oci-ai-inference.yml
+++ b/.github/workflows/oci-ai-inference.yml
@@ -59,8 +59,7 @@ jobs:
             -backend-config="skip_credentials_validation=true" \
             -backend-config="skip_metadata_api_check=true" \
             -backend-config="skip_requesting_account_id=true" \
-            -backend-config="force_path_style=true" \
-            -backend-config="use_lockfile=true"
+            -backend-config="use_path_style=true"
 
       - name: Terraform Plan
         working-directory: ${{ env.TF_WORKING_DIR }}

--- a/.github/workflows/oci-ai-inference.yml
+++ b/.github/workflows/oci-ai-inference.yml
@@ -98,7 +98,26 @@ jobs:
           TF_VAR_availability_domain: ${{ vars.OCI_AVAILABILITY_DOMAIN }}
           TF_VAR_ssh_public_key: ${{ secrets.OCI_SSH_PUBLIC_KEY }}
           TF_VAR_tailscale_auth_key: ${{ secrets.TAILSCALE_AUTH_KEY_OCI }}
-        run: terraform apply -auto-approve -input=false tfplan
+        run: |
+          # OCI Always-Free A1 capacity is often constrained — retry until available.
+          for attempt in $(seq 1 20); do
+            echo "Apply attempt $attempt/20..."
+            if terraform apply -auto-approve -input=false tfplan; then
+              echo "Apply succeeded."
+              exit 0
+            fi
+            if terraform show -json errored.tfstate 2>/dev/null | grep -q "Out of host capacity"; then
+              echo "Out of capacity — waiting 5 min before retry..."
+              sleep 300
+              # Re-plan to get fresh tfplan before next attempt
+              terraform plan -out=tfplan -input=false
+            else
+              echo "Apply failed for non-capacity reason — aborting."
+              exit 1
+            fi
+          done
+          echo "All 20 attempts exhausted."
+          exit 1
 
       - name: Terraform Destroy
         if: >

--- a/.github/workflows/oci-ai-inference.yml
+++ b/.github/workflows/oci-ai-inference.yml
@@ -1,10 +1,6 @@
 name: OCI AI Inference
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "cloud/oci/ai-inference/terraform/**"
   workflow_dispatch:
     inputs:
       action:
@@ -56,7 +52,7 @@ jobs:
             -backend-config="bucket=${TF_BACKEND_BUCKET}" \
             -backend-config="key=${TF_BACKEND_KEY}" \
             -backend-config="region=${TF_BACKEND_REGION}" \
-            -backend-config="endpoint=${TF_BACKEND_ENDPOINT}" \
+            -backend-config="endpoints={s3=\"${TF_BACKEND_ENDPOINT}\"}" \
             -backend-config="access_key=${{ secrets.OCI_STATE_ACCESS_KEY }}" \
             -backend-config="secret_key=${{ secrets.OCI_STATE_SECRET_KEY }}" \
             -backend-config="skip_region_validation=true" \

--- a/cloud/oci/ai-inference/terraform/backend.hcl.example
+++ b/cloud/oci/ai-inference/terraform/backend.hcl.example
@@ -8,7 +8,7 @@ region   = "eu-frankfurt-1"
 
 # OCI Object Storage S3-compat endpoint.
 # Format: https://<namespace>.compat.objectstorage.<region>.oraclecloud.com
-endpoint = "https://<namespace>.compat.objectstorage.eu-frankfurt-1.oraclecloud.com"
+endpoints = { s3 = "https://<namespace>.compat.objectstorage.eu-frankfurt-1.oraclecloud.com" }
 
 # Customer Secret Key (IAM → User → Customer Secret Keys)
 access_key = "YOUR_CUSTOMER_SECRET_KEY_ID"

--- a/cloud/oci/ai-inference/terraform/backend.hcl.example
+++ b/cloud/oci/ai-inference/terraform/backend.hcl.example
@@ -20,3 +20,4 @@ skip_credentials_validation = true
 skip_metadata_api_check     = true
 skip_requesting_account_id  = true
 use_path_style              = true
+skip_s3_checksum            = true

--- a/cloud/oci/ai-inference/terraform/backend.hcl.example
+++ b/cloud/oci/ai-inference/terraform/backend.hcl.example
@@ -19,5 +19,4 @@ skip_region_validation      = true
 skip_credentials_validation = true
 skip_metadata_api_check     = true
 skip_requesting_account_id  = true
-force_path_style            = true
-use_lockfile                = true
+use_path_style              = true


### PR DESCRIPTION
## Summary

- Fix OCI S3-compat backend: `use_path_style`, `skip_s3_checksum` (OCI rejects aws-chunked encoding)
- Remove push trigger — workflow was firing before bootstrap set state credentials
- Fix deprecated `endpoint` → `endpoints.s3`
- Retry loop on apply: 20 attempts × 5-min backoff for OCI A1 capacity constraints

## After merge

1. Delete orphaned OCI resources from Console (VCN `ai-inference` in eu-amsterdam-1)
2. **Actions → OCI AI Inference → apply**
