### PR TITLE
fix: OCI S3 backend skip_s3_checksum + A1 capacity retry loop

### DIFF
--- a/.github/workflows/oci-ai-inference.yml
+++ b/.github/workflows/oci-ai-inference.yml
@@ -59,7 +59,8 @@ jobs:
             -backend-config="skip_credentials_validation=true" \
             -backend-config="skip_metadata_api_check=true" \
             -backend-config="skip_requesting_account_id=true" \
-            -backend-config="use_path_style=true"
+            -backend-config="use_path_style=true" \
+            -backend-config="skip_s3_checksum=true"
 
       - name: Terraform Plan
         working-directory: ${{ env.TF_WORKING_DIR }}

--- a/.github/workflows/oci-ai-inference.yml
+++ b/.github/workflows/oci-ai-inference.yml
@@ -98,7 +98,26 @@ jobs:
           TF_VAR_availability_domain: ${{ vars.OCI_AVAILABILITY_DOMAIN }}
           TF_VAR_ssh_public_key: ${{ secrets.OCI_SSH_PUBLIC_KEY }}
           TF_VAR_tailscale_auth_key: ${{ secrets.TAILSCALE_AUTH_KEY_OCI }}
-        run: terraform apply -auto-approve -input=false tfplan
+        run: |
+          # OCI Always-Free A1 capacity is often constrained — retry until available.
+          for attempt in $(seq 1 20); do
+            echo "Apply attempt $attempt/20..."
+            if terraform apply -auto-approve -input=false tfplan; then
+              echo "Apply succeeded."
+              exit 0
+            fi
+            if terraform show -json errored.tfstate 2>/dev/null | grep -q "Out of host capacity"; then
+              echo "Out of capacity — waiting 5 min before retry..."
+              sleep 300
+              # Re-plan to get fresh tfplan before next attempt
+              terraform plan -out=tfplan -input=false
+            else
+              echo "Apply failed for non-capacity reason — aborting."
+              exit 1
+            fi
+          done
+          echo "All 20 attempts exhausted."
+          exit 1
 
       - name: Terraform Destroy
         if: >

--- a/cloud/oci/ai-inference/terraform/backend.hcl.example
+++ b/cloud/oci/ai-inference/terraform/backend.hcl.example
@@ -20,3 +20,4 @@ skip_credentials_validation = true
 skip_metadata_api_check     = true
 skip_requesting_account_id  = true
 use_path_style              = true
+skip_s3_checksum            = true


### PR DESCRIPTION
## Summary

- Fix OCI S3-compat backend: `use_path_style`, `skip_s3_checksum` (OCI rejects aws-chunked encoding)
- Remove push trigger — workflow was firing before bootstrap set state credentials
- Fix deprecated `endpoint` → `endpoints.s3`
- Retry loop on apply: 20 attempts × 5-min backoff for OCI A1 capacity constraints

## After merge

1. Delete orphaned OCI resources from Console (VCN `ai-inference` in eu-amsterdam-1)
2. **Actions → OCI AI Inference → apply**
