### PR TITLE
fix: disable AWS chunked encoding for OCI S3-compat backend

### DIFF
--- a/.github/workflows/oci-ai-inference.yml
+++ b/.github/workflows/oci-ai-inference.yml
@@ -47,6 +47,9 @@ jobs:
 
       - name: Terraform Init
         working-directory: ${{ env.TF_WORKING_DIR }}
+        env:
+          AWS_REQUEST_CHECKSUM_CALCULATION: when_required
+          AWS_RESPONSE_CHECKSUM_VALIDATION: when_required
         run: |
           terraform init \
             -backend-config="bucket=${TF_BACKEND_BUCKET}" \
@@ -74,6 +77,8 @@ jobs:
           TF_VAR_availability_domain: ${{ vars.OCI_AVAILABILITY_DOMAIN }}
           TF_VAR_ssh_public_key: ${{ secrets.OCI_SSH_PUBLIC_KEY }}
           TF_VAR_tailscale_auth_key: ${{ secrets.TAILSCALE_AUTH_KEY_OCI }}
+          AWS_REQUEST_CHECKSUM_CALCULATION: when_required
+          AWS_RESPONSE_CHECKSUM_VALIDATION: when_required
         run: terraform plan -out=tfplan -input=false
 
       - name: Upload plan artifact
@@ -98,18 +103,22 @@ jobs:
           TF_VAR_availability_domain: ${{ vars.OCI_AVAILABILITY_DOMAIN }}
           TF_VAR_ssh_public_key: ${{ secrets.OCI_SSH_PUBLIC_KEY }}
           TF_VAR_tailscale_auth_key: ${{ secrets.TAILSCALE_AUTH_KEY_OCI }}
+          AWS_REQUEST_CHECKSUM_CALCULATION: when_required
+          AWS_RESPONSE_CHECKSUM_VALIDATION: when_required
         run: |
           # OCI Always-Free A1 capacity is often constrained — retry until available.
           for attempt in $(seq 1 20); do
             echo "Apply attempt $attempt/20..."
-            if terraform apply -auto-approve -input=false tfplan; then
+            apply_output=$(terraform apply -auto-approve -input=false tfplan 2>&1)
+            exit_code=$?
+            echo "$apply_output"
+            if [ $exit_code -eq 0 ]; then
               echo "Apply succeeded."
               exit 0
             fi
-            if terraform show -json errored.tfstate 2>/dev/null | grep -q "Out of host capacity"; then
+            if echo "$apply_output" | grep -q "Out of host capacity"; then
               echo "Out of capacity — waiting 5 min before retry..."
               sleep 300
-              # Re-plan to get fresh tfplan before next attempt
               terraform plan -out=tfplan -input=false
             else
               echo "Apply failed for non-capacity reason — aborting."
@@ -134,4 +143,6 @@ jobs:
           TF_VAR_availability_domain: ${{ vars.OCI_AVAILABILITY_DOMAIN }}
           TF_VAR_ssh_public_key: ${{ secrets.OCI_SSH_PUBLIC_KEY }}
           TF_VAR_tailscale_auth_key: ${{ secrets.TAILSCALE_AUTH_KEY_OCI }}
+          AWS_REQUEST_CHECKSUM_CALCULATION: when_required
+          AWS_RESPONSE_CHECKSUM_VALIDATION: when_required
         run: terraform destroy -auto-approve -input=false


### PR DESCRIPTION
## Summary

- Set `AWS_REQUEST_CHECKSUM_CALCULATION=when_required` + `AWS_RESPONSE_CHECKSUM_VALIDATION=when_required` on all TF steps — stops TF 1.15 AWS SDK v2 from sending `aws-chunked` encoding which OCI S3-compat rejects with 501
- Fix retry loop: capture apply stdout to grep for capacity error instead of parsing errored.tfstate (which contains state data, not error messages)

## After merge

Delete orphaned OCI resources from Console (VCN `ai-inference` in eu-amsterdam-1), then re-run **Actions → OCI AI Inference → apply**
