### PR TITLE
fix: disable terraform wrapper to fix output capture in retry loop

### DIFF
--- a/.github/workflows/oci-ai-inference.yml
+++ b/.github/workflows/oci-ai-inference.yml
@@ -38,6 +38,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
+          terraform_wrapper: false
 
       - name: Write OCI API private key
         run: |


### PR DESCRIPTION
## Summary

Disable `terraform_wrapper` in `hashicorp/setup-terraform`.

The wrapper intercepts stdout/stderr for GitHub step summaries, breaking `$()` subshell output capture and exit code propagation used by the capacity retry loop.
