### PR TITLE
fix: expand HCL variable blocks — semicolons not valid in Terraform

### DIFF
--- a/cloud/oci/experiment/terraform/modules/compute/variables.tf
+++ b/cloud/oci/experiment/terraform/modules/compute/variables.tf
@@ -1,14 +1,61 @@
-variable "compartment_ocid"   { type = string }
-variable "availability_domain" { type = string }
-variable "subnet_id"           { type = string }
-variable "name"                { type = string }
-variable "shape"               { type = string }
-variable "ocpus"               { type = number }
-variable "memory_gbs"          { type = number }
-variable "boot_volume_gb"      { type = number; default = 100 }
-variable "ssh_public_key"      { type = string }
-variable "tailscale_auth_key"  { type = string; sensitive = true }
-variable "ollama_model"        { type = string; default = "" }
-variable "use_vllm"            { type = bool;   default = false }
-variable "vllm_model"          { type = string; default = "" }
-variable "tags"                { type = map(string); default = {} }
+variable "compartment_ocid" {
+  type = string
+}
+
+variable "availability_domain" {
+  type = string
+}
+
+variable "subnet_id" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "shape" {
+  type = string
+}
+
+variable "ocpus" {
+  type = number
+}
+
+variable "memory_gbs" {
+  type = number
+}
+
+variable "boot_volume_gb" {
+  type    = number
+  default = 100
+}
+
+variable "ssh_public_key" {
+  type = string
+}
+
+variable "tailscale_auth_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "ollama_model" {
+  type    = string
+  default = ""
+}
+
+variable "use_vllm" {
+  type    = bool
+  default = false
+}
+
+variable "vllm_model" {
+  type    = string
+  default = ""
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/cloud/oci/experiment/terraform/modules/network/variables.tf
+++ b/cloud/oci/experiment/terraform/modules/network/variables.tf
@@ -1,5 +1,22 @@
-variable "compartment_ocid" { type = string }
-variable "name"             { type = string }
-variable "vcn_cidr"         { type = string; default = "10.20.0.0/16" }
-variable "subnet_cidr"      { type = string; default = "10.20.0.0/24" }
-variable "tags"             { type = map(string); default = {} }
+variable "compartment_ocid" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "vcn_cidr" {
+  type    = string
+  default = "10.20.0.0/16"
+}
+
+variable "subnet_cidr" {
+  type    = string
+  default = "10.20.0.0/24"
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}


### PR DESCRIPTION
Terraform HCL does not support semicolons as argument separators. Expand single-line blocks to multi-line.