### PR TITLE
fix: expand HCL variable blocks in experiment envs

### DIFF
--- a/cloud/oci/experiment/terraform/envs/cpu-baseline/variables.tf
+++ b/cloud/oci/experiment/terraform/envs/cpu-baseline/variables.tf
@@ -1,11 +1,48 @@
-variable "tenancy_ocid"        { type = string }
-variable "user_ocid"           { type = string }
-variable "fingerprint"         { type = string }
-variable "private_key_path"    { type = string; default = "" }
-variable "private_key_content" { type = string; sensitive = true; default = "" }
-variable "region"              { type = string }
-variable "compartment_ocid"    { type = string }
-variable "availability_domain" { type = string }
-variable "ssh_public_key"      { type = string }
-variable "tailscale_auth_key"  { type = string; sensitive = true }
-variable "ollama_model"        { type = string; default = "qwen3:72b" }
+variable "tenancy_ocid" {
+  type = string
+}
+
+variable "user_ocid" {
+  type = string
+}
+
+variable "fingerprint" {
+  type = string
+}
+
+variable "private_key_path" {
+  type    = string
+  default = ""
+}
+
+variable "private_key_content" {
+  type      = string
+  sensitive = true
+  default   = ""
+}
+
+variable "region" {
+  type = string
+}
+
+variable "compartment_ocid" {
+  type = string
+}
+
+variable "availability_domain" {
+  type = string
+}
+
+variable "ssh_public_key" {
+  type = string
+}
+
+variable "tailscale_auth_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "ollama_model" {
+  type    = string
+  default = "qwen3:72b"
+}

--- a/cloud/oci/experiment/terraform/envs/gpu-burst/variables.tf
+++ b/cloud/oci/experiment/terraform/envs/gpu-burst/variables.tf
@@ -1,11 +1,48 @@
-variable "tenancy_ocid"        { type = string }
-variable "user_ocid"           { type = string }
-variable "fingerprint"         { type = string }
-variable "private_key_path"    { type = string; default = "" }
-variable "private_key_content" { type = string; sensitive = true; default = "" }
-variable "region"              { type = string }
-variable "compartment_ocid"    { type = string }
-variable "availability_domain" { type = string }
-variable "ssh_public_key"      { type = string }
-variable "tailscale_auth_key"  { type = string; sensitive = true }
-variable "vllm_model"          { type = string; default = "mistralai/Mistral-7B-Instruct-v0.3" }
+variable "tenancy_ocid" {
+  type = string
+}
+
+variable "user_ocid" {
+  type = string
+}
+
+variable "fingerprint" {
+  type = string
+}
+
+variable "private_key_path" {
+  type    = string
+  default = ""
+}
+
+variable "private_key_content" {
+  type      = string
+  sensitive = true
+  default   = ""
+}
+
+variable "region" {
+  type = string
+}
+
+variable "compartment_ocid" {
+  type = string
+}
+
+variable "availability_domain" {
+  type = string
+}
+
+variable "ssh_public_key" {
+  type = string
+}
+
+variable "tailscale_auth_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "vllm_model" {
+  type    = string
+  default = "mistralai/Mistral-7B-Instruct-v0.3"
+}


### PR DESCRIPTION
Same semicolon fix as #105, applied to cpu-baseline and gpu-burst env variables.tf files.