### PR TITLE
fix: add required_providers to experiment modules for oracle/oci source

### DIFF
--- a/cloud/oci/experiment/terraform/modules/compute/versions.tf
+++ b/cloud/oci/experiment/terraform/modules/compute/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/cloud/oci/experiment/terraform/modules/network/versions.tf
+++ b/cloud/oci/experiment/terraform/modules/network/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
Terraform resolves providers from root module but modules must also declare `oracle/oci` source to avoid being assigned the incorrect `hashicorp/oci` alias.