### PR TITLE
fix(oci): temporarily open SSH port 22 for diagnostics

### DIFF
--- a/cloud/oci/ai-inference/terraform/main.tf
+++ b/cloud/oci/ai-inference/terraform/main.tf
@@ -35,6 +35,7 @@ resource "oci_core_route_table" "public" {
 
 # Minimal ingress: Tailscale direct UDP + HTTPS for Tailscale DERP fallback.
 # SSH (22) intentionally omitted — access via Tailscale only post-bootstrap.
+# TEMP: SSH open for diagnostics — remove once Tailscale is confirmed connected.
 resource "oci_core_security_list" "ai_inference" {
   compartment_id = var.compartment_ocid
   vcn_id         = oci_core_vcn.ai_inference.id
@@ -66,6 +67,17 @@ resource "oci_core_security_list" "ai_inference" {
     tcp_options {
       min = 443
       max = 443
+    }
+  }
+
+  # TEMP: SSH for diagnostics — remove after Tailscale confirmed connected
+  ingress_security_rules {
+    protocol  = "6" # TCP
+    source    = "0.0.0.0/0"
+    stateless = false
+    tcp_options {
+      min = 22
+      max = 22
     }
   }
 }


### PR DESCRIPTION
## Summary
- Opens TCP port 22 ingress in OCI security list temporarily
- Tailscale failed to connect post-bootstrap — VM unreachable for 2 days
- Needed to SSH in directly and diagnose cloud-init / Tailscale failure

## After merge
1. Run **OCI AI Inference → apply** in GitHub Actions
2. SSH in: `ssh ubuntu@134.98.144.243`
3. Check `sudo tail -100 /var/log/cloud-init-output.log` and `sudo systemctl status tailscaled`
4. Fix Tailscale, confirm node appears in tailnet
5. Open a follow-up PR to remove this rule

## Test plan
- [ ] Apply succeeds in GHA
- [ ] `ssh ubuntu@134.98.144.243` connects
- [ ] cloud-init logs reveal root cause