### PR TITLE
chore: add nameserver and searchdomain to proxmox_create_vars example

### DIFF
--- a/vars/proxmox_create_vars.yml.example
+++ b/vars/proxmox_create_vars.yml.example
@@ -6,9 +6,13 @@ proxmox_node: one
 proxmox_api_user: root@pam
 proxmox_api_token_id: "CHANGE_ME"
 proxmox_api_token_secret: "CHANGE_ME"
+
 # Required when proxmox_containers includes privileged containers (unprivileged: 0).
 proxmox_api_password: "CHANGE_ME"
 proxmox_container_password: "CHANGE_ME"
+
+proxmox_nameserver: "192.168.178.253 192.168.178.254"
+proxmox_searchdomain: "mol.la"
 
 # Optional overrides:
 # proxmox_api_host: "192.168.178.110"


### PR DESCRIPTION
## Summary
- Adds `proxmox_nameserver` and `proxmox_searchdomain` fields to `vars/proxmox_create_vars.yml.example`
- Separates API credential block from password block with blank line for readability