### PR TITLE
fix(timothy): correct vault path, add to lab script, update docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,8 @@ Most playbooks need runtime secrets that are gitignored. Copy the `.example` fil
 | deploy_mysql      | `-e "@vars/vault_auth_vars.yml"`                                |
 | deploy_redis      | `-e "@vars/vault_auth_vars.yml"`                                |
 | deploy_immich     | `-e "@vars/vault_auth_vars.yml"`                                |
+| deploy_tailscale  | `-e "@vars/vault_auth_vars.yml"`                                |
+| deploy_timothy    | `-e "@vars/vault_auth_vars.yml"`                                |
 | create_lxc        | `-e "@vars/proxmox_create_vars.yml"`                            |
 
 ### Patterns to Follow When Adding a Service
@@ -194,6 +196,12 @@ Timothy (`192.168.178.125`, vmid 125) runs two containers on an internal `timoth
 `ollama_base_url` points to `oci-ai-inference` over Tailscale — Timothy requires Tailscale to be installed first (deployment order: `node-exporter` → `tailscale` → `timothy`).
 
 `deploy_timothy.yml` chains all three roles in sequence; the `lab` deploy command handles this automatically.
+
+LXC 125 requires `/dev/net/tun` for Tailscale — add to `/etc/pve/lxc/125.conf` on the Proxmox host and restart the container:
+```
+lxc.cgroup2.devices.allow: c 10:200 rwm
+lxc.mount.entry: /dev/net/tun dev/net/tun none bind,create=file
+```
 
 ### lab Script Behavior
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Proxmox VE (192.168.178.110)
 ├── LXC 122  PocketID + Tinyauth (identity / OIDC)
 ├── LXC 123  HashiCorp Vault (secrets)
 ├── LXC 124  Monitoring (Prometheus + Grafana)
-├── LXC 125  LLM (Ollama + Gemma 4)
+├── LXC 125  Timothy (Hermes AI agent)
 ├── LXC 130  PostgreSQL
 ├── LXC 131  MySQL
 ├── LXC 132  Redis
@@ -20,7 +20,6 @@ Proxmox VE (192.168.178.110)
 ├── LXC 141  ARR stack (Radarr, Sonarr, SABnzbd, …)
 ├── LXC 142  Immich (photo/video backup)
 ├── LXC 250  Dash (Dashboard)
-├── LXC 251  Timothy (AI agent)
 ├── LXC 252  Humaun
 ├── LXC 253  AdGuard Home Primary (DNS + DHCP)
 └── LXC 254  AdGuard Home Secondary (DNS)
@@ -173,6 +172,23 @@ ansible-playbook deployments/deploy_immich.yml -e "@vars/vault_auth_vars.yml"
 
 Immich depends on PostgreSQL (with `pgvector`) and Redis being deployed first.
 
+### 10. Timothy (Hermes AI agent)
+
+Timothy requires Tailscale to reach the OCI Ollama inference backend over Tailscale MagicDNS. The playbook chains all three roles automatically:
+
+```bash
+ansible-playbook deployments/deploy_timothy.yml -e "@vars/vault_auth_vars.yml"
+```
+
+Or via the lab script: `./lab deploy timothy`
+
+> **Note:** LXC 125 must have `/dev/net/tun` enabled in its Proxmox config for Tailscale to work. Add to `/etc/pve/lxc/125.conf`:
+> ```
+> lxc.cgroup2.devices.allow: c 10:200 rwm
+> lxc.mount.entry: /dev/net/tun dev/net/tun none bind,create=file
+> ```
+> Then restart the container.
+
 ## Service Dependencies
 
 ```
@@ -189,6 +205,7 @@ PVE Exporter ─ Vault
 Jellyfin ──── (standalone, needs media bind mount)
 ARR ────────── (standalone, needs media bind mount)
 Immich ─────── Vault, PostgreSQL (pgvector), Redis
+Timothy ─────── Vault, Tailscale → OCI Ollama (oci-ai-inference via MagicDNS)
 ```
 
 ## Day-to-Day Operations

--- a/lab
+++ b/lab
@@ -131,13 +131,15 @@ cmd_deploy() {
     [jellyfin]="Jellyfin media server"
     [arr]="*arr stack"
     [immich]="Immich photo/video backup"
-    [llm]="Ollama LLM inference"
+    [tailscale]="Tailscale (all hosts)"
+    [timothy]="Timothy (Hermes AI agent)"
   )
 
   if [[ -z "$service" || -z "${SERVICE_LABELS[$service]+_}" ]]; then
     _header "Deploy — available services"
     for svc in adguard caddy pocketid vault postgresql mysql redis mongodb \
-                monitoring node-exporter pve-exporter jellyfin arr immich llm; do
+                monitoring node-exporter pve-exporter jellyfin arr immich \
+                tailscale timothy; do
       printf "    ${CYAN}%-18s${RESET} %s\n" "$svc" "${SERVICE_LABELS[$svc]}"
     done
     echo ""
@@ -177,7 +179,10 @@ cmd_deploy() {
     arr)           _run ansible-playbook "$DEPLOYMENTS_DIR/deploy_arr.yml" ;;
     immich)        _require_vars vault_auth_vars.yml
                    _run ansible-playbook "$DEPLOYMENTS_DIR/deploy_immich.yml" -e "@$VARS_DIR/vault_auth_vars.yml" ;;
-    llm)           _run ansible-playbook "$DEPLOYMENTS_DIR/deploy_llm.yml" ;;
+    tailscale)     _require_vars vault_auth_vars.yml
+                   _run ansible-playbook "$DEPLOYMENTS_DIR/deploy_tailscale.yml" -e "@$VARS_DIR/vault_auth_vars.yml" ;;
+    timothy)       _require_vars vault_auth_vars.yml
+                   _run ansible-playbook "$DEPLOYMENTS_DIR/deploy_timothy.yml" -e "@$VARS_DIR/vault_auth_vars.yml" ;;
   esac
 
   _ok "Deployed ${SERVICE_LABELS[$service]} in $(_elapsed $start)"
@@ -192,7 +197,7 @@ cmd_upgrade() {
     [pocketid]="192.168.178.122 /opt/compose/pocketid-pocketid"
     [jellyfin]="192.168.178.140 /opt/compose/jellyfin-jellyfin"
     [arr]="192.168.178.141 /opt/compose/arr-arr"
-    [llm]="192.168.178.125 /opt/compose/ollama-llm"
+    [timothy]="192.168.178.125 /opt/compose/timothy-timothy"
   )
 
   declare -A PINNED=(

--- a/roles/timothy/tasks/main.yml
+++ b/roles/timothy/tasks/main.yml
@@ -6,7 +6,7 @@
     role_id: "{{ vault_role_id }}"
     secret_id: "{{ vault_secret_id }}"
     engine_mount_point: kv
-    path: homelab/data/timothy
+    path: homelab/timothy
   register: timothy_vault
   delegate_to: localhost
   become: false


### PR DESCRIPTION
## Summary

- Fixes `vault_kv2_get` path `homelab/data/timothy` → `homelab/timothy` — the extra `/data/` segment caused a 404 against the kv-v2 engine (kv-v2 adds its own `data/` internally)
- Adds `tailscale` and `timothy` as first-class deploy targets in `./lab deploy` and `./lab upgrade`
- Removes stale `llm` entry — LXC 125 is now Timothy (Hermes AI agent), not Ollama
- Documents `/dev/net/tun` LXC requirement for Tailscale in both README and CLAUDE.md
- Corrects README architecture diagram: LXC 125 = Timothy, removes non-existent LXC 251

## Test plan

- [ ] `./lab deploy timothy` completes without error after merge + pull on Ansible host
- [ ] `./lab deploy tailscale --limit timothy` works
- [ ] `./lab upgrade timothy` shows correct host/path
- [ ] `./lab deploy` list shows `tailscale` and `timothy`, no `llm`