### PR TITLE
fix(timothy): switch vault_read, fix kv engine mount path

### DIFF
--- a/roles/timothy/defaults/main.yml
+++ b/roles/timothy/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+timothy_vault_secret_path: "kv/homelab/data/timothy"
 hermes_image: "ghcr.io/nousresearch/hermes-agent:latest"
 hermes_data_dir: "/opt/hermes/data"
 hermes_uid: 1000

--- a/roles/timothy/tasks/main.yml
+++ b/roles/timothy/tasks/main.yml
@@ -1,12 +1,11 @@
 ---
 - name: Read Timothy secrets from Vault
-  community.hashi_vault.vault_kv2_get:
+  community.hashi_vault.vault_read:
     url: "{{ vault_addr }}"
+    path: "{{ timothy_vault_secret_path }}"
     auth_method: approle
     role_id: "{{ vault_role_id }}"
     secret_id: "{{ vault_secret_id }}"
-    engine_mount_point: kv
-    path: homelab/timothy
   register: timothy_vault
   delegate_to: localhost
   become: false
@@ -14,8 +13,8 @@
 
 - name: Set Timothy secrets
   ansible.builtin.set_fact:
-    hermes_api_server_key: "{{ timothy_vault.secret.api_server_key }}"
-    hermes_ollama_base_url: "{{ timothy_vault.secret.ollama_base_url }}"
+    hermes_api_server_key: "{{ timothy_vault.data.data.api_server_key }}"
+    hermes_ollama_base_url: "{{ timothy_vault.data.data.ollama_base_url }}"
   no_log: true
 
 - name: Install Docker


### PR DESCRIPTION
## Summary

- `vault_kv2_get` with `engine_mount_point: kv` resolves API path to `/v1/kv/data/homelab/timothy` — but the kv-v2 engine is mounted at `kv/homelab`, so the actual API path is `/v1/kv/homelab/data/timothy`. AppRole policy covers `kv/homelab/data/*` → 403.
- Switch to `vault_read` (consistent with every other role) using full path `kv/homelab/data/timothy`
- Add `timothy_vault_secret_path` default var

## Test plan

- [ ] `./lab deploy timothy` completes successfully
- [ ] Timothy containers running on 192.168.178.125