### PR TITLE
fix(timothy): correct vault_read kv-v2 accessor to .data.data.data

### DIFF
--- a/roles/timothy/tasks/main.yml
+++ b/roles/timothy/tasks/main.yml
@@ -13,8 +13,8 @@
 
 - name: Set Timothy secrets
   ansible.builtin.set_fact:
-    hermes_api_server_key: "{{ timothy_vault.data.data.api_server_key }}"
-    hermes_ollama_base_url: "{{ timothy_vault.data.data.ollama_base_url }}"
+    hermes_api_server_key: "{{ timothy_vault.data.data.data.api_server_key }}"
+    hermes_ollama_base_url: "{{ timothy_vault.data.data.data.ollama_base_url }}"
   no_log: true
 
 - name: Install Docker


### PR DESCRIPTION
vault_read returns .data (API response), kv-v2 wraps secrets in .data.data — so accessor is .data.data.data.key, matching all other roles (e.g. caddy).