### PR TITLE
fix(timothy): correct hermes image, network_mode, compose structure

### DIFF
--- a/roles/timothy/defaults/main.yml
+++ b/roles/timothy/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 timothy_vault_secret_path: "kv/homelab/data/timothy"
-hermes_image: "ghcr.io/nousresearch/hermes-agent:latest"
+hermes_image: "nousresearch/hermes-agent:latest"
 hermes_data_dir: "/opt/hermes/data"
 hermes_uid: 1000
 hermes_gid: 1000

--- a/roles/timothy/templates/compose.yml.j2
+++ b/roles/timothy/templates/compose.yml.j2
@@ -3,6 +3,7 @@ services:
     image: {{ hermes_image }}
     container_name: timothy-gateway-{{ inventory_hostname }}
     restart: unless-stopped
+    network_mode: host
     volumes:
       - {{ hermes_data_dir }}:/opt/data
     environment:
@@ -10,27 +11,19 @@ services:
       HERMES_GID: "{{ hermes_gid }}"
       OLLAMA_BASE_URL: "{{ hermes_ollama_base_url }}"
       API_SERVER_KEY: "{{ hermes_api_server_key }}"
-    command: gateway run
-    networks:
-      - timothy
+      API_SERVER_HOST: "0.0.0.0"
+    command: ["gateway", "run"]
 
   dashboard:
     image: {{ hermes_image }}
     container_name: timothy-dashboard-{{ inventory_hostname }}
     restart: unless-stopped
-    ports:
-      - "9119:9119"
+    network_mode: host
     volumes:
       - {{ hermes_data_dir }}:/opt/data
     environment:
       HERMES_UID: "{{ hermes_uid }}"
       HERMES_GID: "{{ hermes_gid }}"
-    command: dashboard --host 0.0.0.0 --no-open
+    command: ["dashboard", "--host", "0.0.0.0", "--no-open"]
     depends_on:
       - gateway
-    networks:
-      - timothy
-
-networks:
-  timothy:
-    name: timothy-{{ inventory_hostname }}


### PR DESCRIPTION
## Summary

- Image `ghcr.io/nousresearch/hermes-agent` → `nousresearch/hermes-agent` (Docker Hub, publicly available)
- `network_mode: host` — upstream compose.yml requires this; custom bridge network is incompatible
- Add `API_SERVER_HOST=0.0.0.0` to expose gateway API on LAN (port 8642)
- Fix command to array syntax matching upstream
- Remove unused `timothy` bridge network definition