### PR TITLE
fix(timothy): add --insecure flag to dashboard for LAN binding

### DIFF
--- a/roles/timothy/templates/compose.yml.j2
+++ b/roles/timothy/templates/compose.yml.j2
@@ -24,6 +24,6 @@ services:
     environment:
       HERMES_UID: "{{ hermes_uid }}"
       HERMES_GID: "{{ hermes_gid }}"
-    command: ["dashboard", "--host", "0.0.0.0", "--no-open"]
+    command: ["dashboard", "--host", "0.0.0.0", "--no-open", "--insecure"]
     depends_on:
       - gateway


### PR DESCRIPTION
Dashboard refuses 0.0.0.0 without --insecure. Safe here — LXC is LAN-only, Caddy + Tinyauth provides auth in front.