### PR TITLE
feat(caddy): add timothy.mol.la → Hermes dashboard

### DIFF
--- a/roles/caddy/templates/Caddyfile.j2
+++ b/roles/caddy/templates/Caddyfile.j2
@@ -110,3 +110,9 @@ http://dns1.mol.la, dns1.mol.la {
 http://dns2.mol.la, dns2.mol.la {
 	reverse_proxy 192.168.178.254:80
 }
+
+# Timothy — Hermes AI agent dashboard (protected by Tinyauth)
+http://timothy.mol.la, timothy.mol.la {
+    import protected
+    reverse_proxy {{ hostvars['timothy'].ansible_host }}:9119
+}


### PR DESCRIPTION
Proxies timothy.mol.la → 192.168.178.125:9119 behind Tinyauth. Also: ollama_base_url in Vault updated to Tailscale IP (100.88.117.9:11434) since AdGuard DNS rewrite for oci-ai-inference points to Caddy, not the OCI instance.