### PR TITLE
feat(timothy): configure Hermes to use OCI Ollama (qwen3.6:27b)

### DIFF
--- a/roles/timothy/defaults/main.yml
+++ b/roles/timothy/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 timothy_vault_secret_path: "kv/homelab/data/timothy"
 hermes_image: "nousresearch/hermes-agent:latest"
+hermes_model: "qwen3.6:27b"
 hermes_data_dir: "/opt/hermes/data"
 hermes_uid: 1000
 hermes_gid: 1000

--- a/roles/timothy/templates/compose.yml.j2
+++ b/roles/timothy/templates/compose.yml.j2
@@ -12,6 +12,8 @@ services:
       OLLAMA_BASE_URL: "{{ hermes_ollama_base_url }}"
       API_SERVER_KEY: "{{ hermes_api_server_key }}"
       API_SERVER_HOST: "0.0.0.0"
+      HERMES_INFERENCE_PROVIDER: "ollama"
+      HERMES_MODEL: "{{ hermes_model }}"
     command: ["gateway", "run"]
 
   dashboard:


### PR DESCRIPTION
Set HERMES_INFERENCE_PROVIDER=ollama and HERMES_MODEL=qwen3.6:27b so gateway uses the self-hosted OCI Ollama instance instead of defaulting to Anthropic/OpenRouter.