### PR TITLE
fix(timothy): configure Hermes provider via hermes config set

### DIFF
--- a/roles/timothy/tasks/main.yml
+++ b/roles/timothy/tasks/main.yml
@@ -45,3 +45,18 @@
     project_src: /opt/compose/timothy-{{ inventory_hostname }}
     state: present
     pull: always
+
+- name: Wait for Hermes to initialize config
+  ansible.builtin.wait_for:
+    path: "{{ hermes_data_dir }}/config.yaml"
+    timeout: 30
+
+- name: Configure Hermes model provider
+  community.docker.docker_container_exec:
+    container: timothy-gateway-{{ inventory_hostname }}
+    command: /opt/hermes/.venv/bin/hermes config set {{ item.key }} {{ item.value }}
+  loop:
+    - { key: "model.provider", value: "custom" }
+    - { key: "model.default", value: "{{ hermes_model }}" }
+    - { key: "model.base_url", value: "{{ hermes_ollama_base_url }}/v1" }
+  notify: restart timothy

--- a/roles/timothy/templates/compose.yml.j2
+++ b/roles/timothy/templates/compose.yml.j2
@@ -12,8 +12,6 @@ services:
       OLLAMA_BASE_URL: "{{ hermes_ollama_base_url }}"
       API_SERVER_KEY: "{{ hermes_api_server_key }}"
       API_SERVER_HOST: "0.0.0.0"
-      HERMES_INFERENCE_PROVIDER: "ollama"
-      HERMES_MODEL: "{{ hermes_model }}"
     command: ["gateway", "run"]
 
   dashboard:


### PR DESCRIPTION
HERMES_INFERENCE_PROVIDER env var has no effect. Use docker_container_exec to run hermes config set after container starts, setting model.provider=custom, model.default=qwen3.6:27b, model.base_url to OCI Ollama Tailscale IP.