### PR TITLE
fix(timothy): use command module for hermes config set

### DIFF
--- a/roles/timothy/tasks/main.yml
+++ b/roles/timothy/tasks/main.yml
@@ -52,11 +52,12 @@
     timeout: 30
 
 - name: Configure Hermes model provider
-  community.docker.docker_container_exec:
-    container: timothy-gateway-{{ inventory_hostname }}
-    command: /opt/hermes/.venv/bin/hermes config set {{ item.key }} {{ item.value }}
+  ansible.builtin.command: >
+    docker exec timothy-gateway-{{ inventory_hostname }}
+    /opt/hermes/.venv/bin/hermes config set {{ item.key }} {{ item.value }}
   loop:
     - { key: "model.provider", value: "custom" }
     - { key: "model.default", value: "{{ hermes_model }}" }
     - { key: "model.base_url", value: "{{ hermes_ollama_base_url }}/v1" }
+  changed_when: false
   notify: restart timothy


### PR DESCRIPTION
docker_container_exec requires Python requests on target. Use ansible.builtin.command with docker exec instead.