### PR TITLE
feat(oci): IaC model management — switch to qwen3:8b, add Ansible role

### DIFF
--- a/.github/workflows/oci-ai-inference.yml
+++ b/.github/workflows/oci-ai-inference.yml
@@ -4,14 +4,19 @@ on:
   workflow_dispatch:
     inputs:
       action:
-        description: "Terraform action"
+        description: "Action"
         required: true
         default: plan
         type: choice
         options:
           - plan
           - apply
+          - deploy
           - destroy
+      ollama_model:
+        description: "Ollama model tag (leave blank for default: qwen3:8b)"
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -19,6 +24,7 @@ permissions:
 env:
   TF_VERSION: "1.15.1"
   TF_WORKING_DIR: cloud/oci/ai-inference/terraform
+  ANSIBLE_WORKING_DIR: cloud/oci/ai-inference/ansible
   # OCI S3-compat backend
   TF_BACKEND_BUCKET: ${{ vars.OCI_STATE_BUCKET }}
   TF_BACKEND_KEY: "oci-ai-inference/terraform.tfstate"
@@ -46,6 +52,12 @@ jobs:
           echo "${{ secrets.OCI_PRIVATE_KEY_CONTENT }}" > ~/.oci/oci_api_key.pem
           chmod 600 ~/.oci/oci_api_key.pem
 
+      - name: Write SSH key for OCI instance
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.OCI_SSH_PRIVATE_KEY }}" > ~/.ssh/oci_inference
+          chmod 600 ~/.ssh/oci_inference
+
       - name: Terraform Init
         working-directory: ${{ env.TF_WORKING_DIR }}
         env:
@@ -67,6 +79,7 @@ jobs:
             -backend-config="skip_s3_checksum=true"
 
       - name: Terraform Plan
+        if: github.event.inputs.action != 'deploy'
         working-directory: ${{ env.TF_WORKING_DIR }}
         env:
           TF_VAR_tenancy_ocid: ${{ secrets.OCI_TENANCY_OCID }}
@@ -78,11 +91,13 @@ jobs:
           TF_VAR_availability_domain: ${{ vars.OCI_AVAILABILITY_DOMAIN }}
           TF_VAR_ssh_public_key: ${{ secrets.OCI_SSH_PUBLIC_KEY }}
           TF_VAR_tailscale_auth_key: ${{ secrets.TAILSCALE_AUTH_KEY_OCI }}
+          TF_VAR_ollama_model: ${{ github.event.inputs.ollama_model || 'qwen3:8b' }}
           AWS_REQUEST_CHECKSUM_CALCULATION: when_required
           AWS_RESPONSE_CHECKSUM_VALIDATION: when_required
         run: terraform plan -out=tfplan -input=false
 
       - name: Upload plan artifact
+        if: github.event.inputs.action != 'deploy'
         uses: actions/upload-artifact@v4
         with:
           name: tfplan
@@ -104,6 +119,7 @@ jobs:
           TF_VAR_availability_domain: ${{ vars.OCI_AVAILABILITY_DOMAIN }}
           TF_VAR_ssh_public_key: ${{ secrets.OCI_SSH_PUBLIC_KEY }}
           TF_VAR_tailscale_auth_key: ${{ secrets.TAILSCALE_AUTH_KEY_OCI }}
+          TF_VAR_ollama_model: ${{ github.event.inputs.ollama_model || 'qwen3:8b' }}
           AWS_REQUEST_CHECKSUM_CALCULATION: when_required
           AWS_RESPONSE_CHECKSUM_VALIDATION: when_required
         run: |
@@ -129,6 +145,43 @@ jobs:
           echo "All 20 attempts exhausted."
           exit 1
 
+      - name: Install Tailscale (CI runner)
+        if: >
+          (github.event.inputs.action == 'apply' ||
+           github.event.inputs.action == 'deploy') &&
+          github.ref == 'refs/heads/main'
+        run: |
+          curl -fsSL https://tailscale.com/install.sh | sh
+          sudo tailscale up --authkey=${{ secrets.TAILSCALE_AUTH_KEY_CI }} --hostname=ci-oci-deploy --ephemeral
+          sleep 5
+          tailscale status
+
+      - name: Install Ansible + collections
+        if: >
+          (github.event.inputs.action == 'apply' ||
+           github.event.inputs.action == 'deploy') &&
+          github.ref == 'refs/heads/main'
+        run: |
+          pip install ansible
+          ansible-galaxy collection install community.general
+
+      - name: Run Ansible — configure Ollama
+        if: >
+          (github.event.inputs.action == 'apply' ||
+           github.event.inputs.action == 'deploy') &&
+          github.ref == 'refs/heads/main'
+        working-directory: ${{ env.ANSIBLE_WORKING_DIR }}
+        env:
+          ANSIBLE_HOST_KEY_CHECKING: "False"
+          OLLAMA_MODEL: ${{ github.event.inputs.ollama_model || 'qwen3:8b' }}
+        run: |
+          ansible-playbook playbooks/deploy_oci_ollama.yml \
+            -i oci-ai-inference, \
+            -e "ansible_user=ubuntu" \
+            -e "ansible_ssh_private_key_file=~/.ssh/oci_inference" \
+            -e "ansible_host=oci-ai-inference" \
+            -e "ollama_model=${OLLAMA_MODEL}"
+
       - name: Terraform Destroy
         if: >
           github.event.inputs.action == 'destroy' &&
@@ -144,6 +197,7 @@ jobs:
           TF_VAR_availability_domain: ${{ vars.OCI_AVAILABILITY_DOMAIN }}
           TF_VAR_ssh_public_key: ${{ secrets.OCI_SSH_PUBLIC_KEY }}
           TF_VAR_tailscale_auth_key: ${{ secrets.TAILSCALE_AUTH_KEY_OCI }}
+          TF_VAR_ollama_model: ${{ github.event.inputs.ollama_model || 'qwen3:8b' }}
           AWS_REQUEST_CHECKSUM_CALCULATION: when_required
           AWS_RESPONSE_CHECKSUM_VALIDATION: when_required
         run: terraform destroy -auto-approve -input=false

--- a/cloud/oci/ai-inference/ansible/roles/oci_ollama/defaults/main.yml
+++ b/cloud/oci/ai-inference/ansible/roles/oci_ollama/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+ollama_model: "qwen3:8b"
+ollama_host: "0.0.0.0:11434"
+ollama_keep_alive: "10m"
+ollama_max_loaded_models: 1
+ollama_num_parallel: 1

--- a/cloud/oci/ai-inference/ansible/roles/oci_ollama/handlers/main.yml
+++ b/cloud/oci/ai-inference/ansible/roles/oci_ollama/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart ollama
+  ansible.builtin.systemd:
+    name: ollama
+    state: restarted

--- a/cloud/oci/ai-inference/ansible/roles/oci_ollama/tasks/main.yml
+++ b/cloud/oci/ai-inference/ansible/roles/oci_ollama/tasks/main.yml
@@ -1,0 +1,75 @@
+---
+- name: Configure Ollama environment
+  ansible.builtin.copy:
+    dest: /etc/ollama/environment
+    owner: root
+    group: ollama
+    mode: "0640"
+    content: |
+      OLLAMA_HOST={{ ollama_host }}
+      OLLAMA_MODELS=/var/lib/ollama/models
+      OLLAMA_MAX_LOADED_MODELS={{ ollama_max_loaded_models }}
+      OLLAMA_KEEP_ALIVE={{ ollama_keep_alive }}
+      OLLAMA_NUM_PARALLEL={{ ollama_num_parallel }}
+  notify: restart ollama
+
+- name: Ensure Ollama is running
+  ansible.builtin.systemd:
+    name: ollama
+    state: started
+    enabled: true
+
+- name: Wait for Ollama API
+  ansible.builtin.uri:
+    url: http://127.0.0.1:11434/
+    method: GET
+  register: ollama_ready
+  until: ollama_ready.status == 200
+  retries: 12
+  delay: 5
+
+- name: Get currently loaded models
+  ansible.builtin.uri:
+    url: http://127.0.0.1:11434/api/ps
+    method: GET
+    return_content: true
+  register: ollama_ps
+
+- name: Unload all running models before switching
+  ansible.builtin.uri:
+    url: http://127.0.0.1:11434/api/generate
+    method: POST
+    body_format: json
+    body:
+      model: "{{ item.name }}"
+      keep_alive: 0
+  loop: "{{ (ollama_ps.content | from_json).models }}"
+  when: (ollama_ps.content | from_json).models | length > 0
+
+- name: Pull target model
+  ansible.builtin.uri:
+    url: http://127.0.0.1:11434/api/pull
+    method: POST
+    body_format: json
+    body:
+      model: "{{ ollama_model }}"
+    timeout: 3600
+  register: pull_result
+  changed_when: "'success' in pull_result.content"
+
+- name: Get all local models
+  ansible.builtin.uri:
+    url: http://127.0.0.1:11434/api/tags
+    method: GET
+    return_content: true
+  register: ollama_tags
+
+- name: Remove models that are not the target
+  ansible.builtin.uri:
+    url: http://127.0.0.1:11434/api/delete
+    method: DELETE
+    body_format: json
+    body:
+      model: "{{ item.name }}"
+  loop: "{{ (ollama_tags.content | from_json).models }}"
+  when: item.name != ollama_model

--- a/cloud/oci/ai-inference/terraform/variables.tf
+++ b/cloud/oci/ai-inference/terraform/variables.tf
@@ -67,7 +67,7 @@ variable "boot_volume_size_gb" {
 variable "ollama_model" {
   type        = string
   description = "Ollama model tag to pull on first boot (see https://ollama.com/library/qwen3)"
-  default     = "qwen3.6:27b"
+  default     = "qwen3:8b"
 }
 
 variable "instance_shape" {


### PR DESCRIPTION
## Summary

- `qwen3.6:27b` (17GB) is too slow on A1 Flex CPU-only (<1 t/s). Switch to `qwen3:8b` (~5.2GB, ~6-9 t/s).
- New `oci_ollama` Ansible role: idempotent model lifecycle — unloads running models, pulls target, removes others.
- CI workflow gains `deploy` action (Ansible-only, no Terraform), `ollama_model` input to switch models without reprovisioning, Tailscale + Ansible steps after `apply`.

## New secrets required

- `OCI_SSH_PRIVATE_KEY` — private key matching `OCI_SSH_PUBLIC_KEY` (for Ansible SSH to OCI instance)
- `TAILSCALE_AUTH_KEY_CI` — ephemeral Tailscale key for CI runner to reach `oci-ai-inference` over MagicDNS

## Test plan

- [ ] Trigger workflow with `action=deploy` — should pull qwen3:8b and remove qwen3.6:27b
- [ ] Verify inference responds in <30s via `curl http://100.88.117.9:11434/v1/chat/completions`
- [ ] Timothy gateway produces a response end-to-end