### PR TITLE
fix(oci): enable Tailscale SSH in cloud-init

### DIFF
--- a/cloud/oci/ai-inference/terraform/files/cloud-init.yml.tftpl
+++ b/cloud/oci/ai-inference/terraform/files/cloud-init.yml.tftpl
@@ -92,7 +92,7 @@ runcmd:
   - apt-get update -qq
   - apt-get install -y tailscale
   - systemctl enable --now tailscaled
-  - tailscale up --authkey="${tailscale_auth_key}" --hostname="${hostname}" --advertise-tags="tag:homelab" --accept-dns=false
+  - tailscale up --authkey="${tailscale_auth_key}" --hostname="${hostname}" --advertise-tags="tag:homelab" --accept-dns=false --ssh
 
   # ── Ollama ─────────────────────────────────────────────────────────────────
   # Download the official ARM64 binary directly (avoids pipe-to-shell).


### PR DESCRIPTION
Add --ssh to tailscale up so the instance is always reachable via Tailscale SSH regardless of SSH key state.