### PR TITLE
fix(ci): use --auth-key flag for tailscale up

### DIFF
--- a/.github/workflows/oci-ai-inference.yml
+++ b/.github/workflows/oci-ai-inference.yml
@@ -154,7 +154,7 @@ jobs:
           TAILSCALE_AUTH_KEY: ${{ secrets.TAILSCALE_AUTH_KEY_CI }}
         run: |
           curl -fsSL https://tailscale.com/install.sh | sh
-          sudo tailscale up --authkey="$TAILSCALE_AUTH_KEY" --hostname=ci-oci-deploy --ephemeral
+          sudo tailscale up --auth-key="$TAILSCALE_AUTH_KEY" --hostname=ci-oci-deploy --ephemeral
           sleep 5
           tailscale status
 


### PR DESCRIPTION
## Summary
- `--authkey` is deprecated in recent Tailscale versions and exits with code 2
- Replace with `--auth-key` (current flag name)

## Test plan
- [ ] Trigger `oci-ai-inference` workflow with `apply` action — Tailscale step should succeed