### PR TITLE
fix(ci): remove --ephemeral flag from tailscale up

### DIFF
--- a/.github/workflows/oci-ai-inference.yml
+++ b/.github/workflows/oci-ai-inference.yml
@@ -154,7 +154,7 @@ jobs:
           TAILSCALE_AUTH_KEY: ${{ secrets.TAILSCALE_AUTH_KEY_CI }}
         run: |
           curl -fsSL https://tailscale.com/install.sh | sh
-          sudo tailscale up --auth-key="$TAILSCALE_AUTH_KEY" --hostname=ci-oci-deploy --ephemeral
+          sudo tailscale up --auth-key="$TAILSCALE_AUTH_KEY" --hostname=ci-oci-deploy
           sleep 5
           tailscale status
 


### PR DESCRIPTION
## Summary
- `--ephemeral` is not a valid `tailscale up` flag — ephemeral is a property set on the auth key at generation time, not a CLI option
- Removing it fixes the `flag provided but not defined: -ephemeral` error (exit code 2)