### PR TITLE
fix(oci): add ansible.cfg so playbook resolves oci_ollama role

### DIFF
--- a/cloud/oci/ai-inference/ansible/ansible.cfg
+++ b/cloud/oci/ai-inference/ansible/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = roles


### PR DESCRIPTION
## Summary
- Ansible looks for roles relative to the playbook dir (`playbooks/roles/`) by default
- Role lives at `ansible/roles/oci_ollama/`
- Add `ansible.cfg` in `ansible/` with `roles_path = roles` so it resolves correctly when run from `ANSIBLE_WORKING_DIR`