### PR TITLE
fix(oci): use hosts:all in playbook; wait for tailscale before ansible

### DIFF
--- a/.github/workflows/oci-ai-inference.yml
+++ b/.github/workflows/oci-ai-inference.yml
@@ -167,6 +167,24 @@ jobs:
           pip install ansible
           ansible-galaxy collection install community.general
 
+      - name: Wait for OCI instance to join Tailscale
+        if: >
+          (github.event.inputs.action == 'apply' ||
+           github.event.inputs.action == 'deploy') &&
+          github.ref == 'refs/heads/main'
+        run: |
+          echo "Waiting for oci-ai-inference to appear online in Tailscale..."
+          for i in $(seq 1 24); do
+            if tailscale status --json 2>/dev/null | grep -q '"HostName":"oci-ai-inference"'; then
+              echo "oci-ai-inference is online."
+              exit 0
+            fi
+            echo "Attempt $i/24 — not yet online, waiting 30s..."
+            sleep 30
+          done
+          echo "Timed out waiting for oci-ai-inference."
+          exit 1
+
       - name: Run Ansible — configure Ollama
         if: >
           (github.event.inputs.action == 'apply' ||

--- a/cloud/oci/ai-inference/ansible/playbooks/deploy_oci_ollama.yml
+++ b/cloud/oci/ai-inference/ansible/playbooks/deploy_oci_ollama.yml
@@ -3,7 +3,7 @@
 # Requires Tailscale connectivity to the target host.
 # Usage: ansible-playbook cloud/oci/ai-inference/ansible/playbooks/deploy_oci_ollama.yml
 - name: Configure OCI AI inference node
-  hosts: oci_host
+  hosts: all
   become: true
   roles:
     - role: oci_ollama


### PR DESCRIPTION
## Summary
- `hosts: oci_host` doesn't match the ad-hoc inventory `-i oci-ai-inference,` → changed to `hosts: all`
- New OCI instance needs time for cloud-init to run Tailscale join before Ansible can reach it via MagicDNS — add a 12-minute wait loop (24×30s) checking `tailscale status --json`