### PR TITLE
fix(ci): use tailscale ping to wait for oci instance; extend timeout to 20min

### DIFF
--- a/.github/workflows/oci-ai-inference.yml
+++ b/.github/workflows/oci-ai-inference.yml
@@ -174,12 +174,12 @@ jobs:
           github.ref == 'refs/heads/main'
         run: |
           echo "Waiting for oci-ai-inference to appear online in Tailscale..."
-          for i in $(seq 1 24); do
-            if tailscale status --json 2>/dev/null | grep -q '"HostName":"oci-ai-inference"'; then
-              echo "oci-ai-inference is online."
+          for i in $(seq 1 40); do
+            if tailscale ping -c 1 oci-ai-inference >/dev/null 2>&1; then
+              echo "oci-ai-inference is reachable."
               exit 0
             fi
-            echo "Attempt $i/24 — not yet online, waiting 30s..."
+            echo "Attempt $i/40 — not yet reachable, waiting 30s..."
             sleep 30
           done
           echo "Timed out waiting for oci-ai-inference."


### PR DESCRIPTION
## Summary
- `tailscale status --json | grep` was checking compact JSON but output has spaces; also matched stale offline nodes
- Replace with `tailscale ping -c 1 oci-ai-inference` — actually verifies reachability
- Extend budget from 12 min (24×30s) to 20 min (40×30s) — OCI cloud-init needs more time for package upgrade + Tailscale install