### PR TITLE
fix(oci): pin ollama binary to v0.23.2

### DIFF
--- a/cloud/oci/ai-inference/terraform/files/cloud-init.yml.tftpl
+++ b/cloud/oci/ai-inference/terraform/files/cloud-init.yml.tftpl
@@ -96,7 +96,7 @@ runcmd:
 
   # ── Ollama ─────────────────────────────────────────────────────────────────
   # Download the official ARM64 binary directly (avoids pipe-to-shell).
-  - curl -fsSL https://github.com/ollama/ollama/releases/latest/download/ollama-linux-arm64 -o /usr/local/bin/ollama
+  - curl -fsSL https://github.com/ollama/ollama/releases/download/v0.23.2/ollama-linux-arm64 -o /usr/local/bin/ollama
   - chmod +x /usr/local/bin/ollama
   # Create ollama system user and model storage directory
   - useradd -r -s /bin/false -m -d /var/lib/ollama ollama 2>/dev/null || true


### PR DESCRIPTION
## Summary
- `/releases/latest/download/` URL redirects fail intermittently in cloud-init — results in 404 and missing binary
- Pin to explicit version v0.23.2 (current latest)