### PR TITLE
fix(oci): ansible role installs ollama binary if missing from cloud-init failure

### DIFF
--- a/cloud/oci/ai-inference/ansible/roles/oci_ollama/defaults/main.yml
+++ b/cloud/oci/ai-inference/ansible/roles/oci_ollama/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+ollama_version: "v0.23.2"
 ollama_model: "qwen3:8b"
 ollama_host: "0.0.0.0:11434"
 ollama_keep_alive: "10m"

--- a/cloud/oci/ai-inference/ansible/roles/oci_ollama/handlers/main.yml
+++ b/cloud/oci/ai-inference/ansible/roles/oci_ollama/handlers/main.yml
@@ -3,3 +3,5 @@
   ansible.builtin.systemd:
     name: ollama
     state: restarted
+    daemon_reload: true
+    enabled: true

--- a/cloud/oci/ai-inference/ansible/roles/oci_ollama/tasks/main.yml
+++ b/cloud/oci/ai-inference/ansible/roles/oci_ollama/tasks/main.yml
@@ -1,4 +1,63 @@
 ---
+- name: Check if Ollama binary exists
+  ansible.builtin.stat:
+    path: /usr/local/bin/ollama
+  register: ollama_binary
+
+- name: Install Ollama binary
+  ansible.builtin.get_url:
+    url: "https://github.com/ollama/ollama/releases/download/{{ ollama_version }}/ollama-linux-arm64"
+    dest: /usr/local/bin/ollama
+    mode: "0755"
+  when: not ollama_binary.stat.exists
+  notify: restart ollama
+
+- name: Ensure ollama user exists
+  ansible.builtin.user:
+    name: ollama
+    system: true
+    shell: /bin/false
+    home: /var/lib/ollama
+    create_home: true
+  when: not ollama_binary.stat.exists
+
+- name: Ensure ollama directories exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: ollama
+    group: ollama
+    mode: "0755"
+  loop:
+    - /var/lib/ollama/models
+    - /etc/ollama
+  when: not ollama_binary.stat.exists
+
+- name: Deploy Ollama systemd unit
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/ollama.service
+    mode: "0644"
+    content: |
+      [Unit]
+      Description=Ollama Service
+      After=network-online.target
+      Wants=network-online.target
+
+      [Service]
+      User=ollama
+      Group=ollama
+      EnvironmentFile=/etc/ollama/environment
+      ExecStart=/usr/local/bin/ollama serve
+      Restart=always
+      RestartSec=3
+      StandardOutput=journal
+      StandardError=journal
+
+      [Install]
+      WantedBy=multi-user.target
+  when: not ollama_binary.stat.exists
+  notify: restart ollama
+
 - name: Configure Ollama environment
   ansible.builtin.copy:
     dest: /etc/ollama/environment


### PR DESCRIPTION
## Summary
- cloud-init Ollama binary download can fail (404 on redirect, package install failure)
- Ansible role now checks for `/usr/local/bin/ollama` and installs it if missing
- Also creates ollama user, directories, and systemd unit if needed
- Adds `ollama_version` default (v0.23.2) to match pinned cloud-init version