### PR TITLE
fix(oci): install ollama from tarball (binary-only release gone)

### DIFF
--- a/cloud/oci/ai-inference/ansible/roles/oci_ollama/tasks/main.yml
+++ b/cloud/oci/ai-inference/ansible/roles/oci_ollama/tasks/main.yml
@@ -4,11 +4,28 @@
     path: /usr/local/bin/ollama
   register: ollama_binary
 
-- name: Install Ollama binary
+- name: Ensure zstd is installed
+  ansible.builtin.apt:
+    name: zstd
+    state: present
+  when: not ollama_binary.stat.exists
+
+- name: Download Ollama tarball
   ansible.builtin.get_url:
-    url: "https://github.com/ollama/ollama/releases/download/{{ ollama_version }}/ollama-linux-arm64"
-    dest: /usr/local/bin/ollama
-    mode: "0755"
+    url: "https://github.com/ollama/ollama/releases/download/{{ ollama_version }}/ollama-linux-arm64.tar.zst"
+    dest: /tmp/ollama-linux-arm64.tar.zst
+    mode: "0644"
+  when: not ollama_binary.stat.exists
+
+- name: Extract Ollama binary from tarball
+  ansible.builtin.shell: |
+    cd /tmp
+    tar --use-compress-program=unzstd -xf ollama-linux-arm64.tar.zst ./bin/ollama
+    mv /tmp/bin/ollama /usr/local/bin/ollama
+    chmod +x /usr/local/bin/ollama
+    rm -rf /tmp/bin /tmp/ollama-linux-arm64.tar.zst
+  args:
+    creates: /usr/local/bin/ollama
   when: not ollama_binary.stat.exists
   notify: restart ollama
 

--- a/cloud/oci/ai-inference/terraform/files/cloud-init.yml.tftpl
+++ b/cloud/oci/ai-inference/terraform/files/cloud-init.yml.tftpl
@@ -14,6 +14,7 @@ packages:
   - prometheus-node-exporter
   - ca-certificates
   - gnupg
+  - zstd
 
 write_files:
   - path: /etc/ollama/environment
@@ -96,8 +97,11 @@ runcmd:
 
   # ── Ollama ─────────────────────────────────────────────────────────────────
   # Download the official ARM64 binary directly (avoids pipe-to-shell).
-  - curl -fsSL https://github.com/ollama/ollama/releases/download/v0.23.2/ollama-linux-arm64 -o /usr/local/bin/ollama
+  - curl -fsSL https://github.com/ollama/ollama/releases/download/v0.23.2/ollama-linux-arm64.tar.zst -o /tmp/ollama.tar.zst
+  - tar --use-compress-program=unzstd -xf /tmp/ollama.tar.zst -C /tmp ./bin/ollama
+  - mv /tmp/bin/ollama /usr/local/bin/ollama
   - chmod +x /usr/local/bin/ollama
+  - rm -rf /tmp/bin /tmp/ollama.tar.zst
   # Create ollama system user and model storage directory
   - useradd -r -s /bin/false -m -d /var/lib/ollama ollama 2>/dev/null || true
   - mkdir -p /var/lib/ollama/models /etc/ollama


### PR DESCRIPTION
## Summary
- Ollama switched from single binary to tarball format — `ollama-linux-arm64` 404s
- Update cloud-init and Ansible role to download `ollama-linux-arm64.tar.zst` and extract `./bin/ollama`
- Add `zstd` to cloud-init packages and Ansible apt install