### PR TITLE
fix(oci): flush handlers and daemon-reload before starting ollama

### DIFF
--- a/cloud/oci/ai-inference/ansible/roles/oci_ollama/tasks/main.yml
+++ b/cloud/oci/ai-inference/ansible/roles/oci_ollama/tasks/main.yml
@@ -89,11 +89,15 @@
       OLLAMA_NUM_PARALLEL={{ ollama_num_parallel }}
   notify: restart ollama
 
+- name: Flush handlers before starting Ollama
+  ansible.builtin.meta: flush_handlers
+
 - name: Ensure Ollama is running
   ansible.builtin.systemd:
     name: ollama
     state: started
     enabled: true
+    daemon_reload: true
 
 - name: Wait for Ollama API
   ansible.builtin.uri:


### PR DESCRIPTION
## Summary
- Handlers (restart ollama) fire at play end by default, after Wait for Ollama API already fails
- Add `meta: flush_handlers` before starting service + `daemon_reload: true` on systemd task