### PR TITLE
fix(oci): remove ./ prefix from tar extract path for ollama binary

### DIFF
--- a/cloud/oci/ai-inference/ansible/roles/oci_ollama/tasks/main.yml
+++ b/cloud/oci/ai-inference/ansible/roles/oci_ollama/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: Extract Ollama binary from tarball
   ansible.builtin.shell: |
     cd /tmp
-    tar --use-compress-program=unzstd -xf ollama-linux-arm64.tar.zst ./bin/ollama
+    tar --use-compress-program=unzstd -xf ollama-linux-arm64.tar.zst bin/ollama
     mv /tmp/bin/ollama /usr/local/bin/ollama
     chmod +x /usr/local/bin/ollama
     rm -rf /tmp/bin /tmp/ollama-linux-arm64.tar.zst

--- a/cloud/oci/ai-inference/terraform/files/cloud-init.yml.tftpl
+++ b/cloud/oci/ai-inference/terraform/files/cloud-init.yml.tftpl
@@ -98,7 +98,7 @@ runcmd:
   # ── Ollama ─────────────────────────────────────────────────────────────────
   # Download the official ARM64 binary directly (avoids pipe-to-shell).
   - curl -fsSL https://github.com/ollama/ollama/releases/download/v0.23.2/ollama-linux-arm64.tar.zst -o /tmp/ollama.tar.zst
-  - tar --use-compress-program=unzstd -xf /tmp/ollama.tar.zst -C /tmp ./bin/ollama
+  - tar --use-compress-program=unzstd -xf /tmp/ollama.tar.zst -C /tmp bin/ollama
   - mv /tmp/bin/ollama /usr/local/bin/ollama
   - chmod +x /usr/local/bin/ollama
   - rm -rf /tmp/bin /tmp/ollama.tar.zst


### PR DESCRIPTION
## Summary
- Tarball entries are `bin/ollama` not `./bin/ollama` — tar exits with "Not found in archive"
- Remove leading `./` from extract path in both Ansible role and cloud-init