### PR TITLE
fix(oci): set changed_when:false on ollama pull task

### DIFF
--- a/cloud/oci/ai-inference/ansible/roles/oci_ollama/tasks/main.yml
+++ b/cloud/oci/ai-inference/ansible/roles/oci_ollama/tasks/main.yml
@@ -135,7 +135,7 @@
       model: "{{ ollama_model }}"
     timeout: 3600
   register: pull_result
-  changed_when: "'success' in pull_result.content"
+  changed_when: false
 
 - name: Get all local models
   ansible.builtin.uri:


### PR DESCRIPTION
## Summary
- Ollama /api/pull returns streaming NDJSON (chunked) — no `.content` field in response
- `changed_when: "'success' in pull_result.content"` errors on dict with no content attr
- Use `changed_when: false` — pull is idempotent anyway