### PR TITLE
fix(timothy): set hermes_model default to qwen3:8b

### DIFF
--- a/roles/timothy/defaults/main.yml
+++ b/roles/timothy/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 timothy_vault_secret_path: "kv/homelab/data/timothy"
 hermes_image: "nousresearch/hermes-agent:latest"
-hermes_model: "qwen3.6:27b"
+hermes_model: "qwen3:8b"
 hermes_data_dir: "/opt/hermes/data"
 hermes_uid: 1000
 hermes_gid: 1000


### PR DESCRIPTION
## Summary
- OCI inference backend runs qwen3:8b — hermes_model default was stale qwen3.6:27b