### PR TITLE
fix(timothy): fix config.yaml ownership so hermes container can read it

### DIFF
--- a/roles/timothy/tasks/main.yml
+++ b/roles/timothy/tasks/main.yml
@@ -61,3 +61,11 @@
     - { key: "model.base_url", value: "{{ hermes_ollama_base_url }}/v1" }
   changed_when: false
   notify: restart timothy
+
+- name: Fix config.yaml ownership so container user can read it
+  ansible.builtin.file:
+    path: "{{ hermes_data_dir }}/config.yaml"
+    owner: "{{ hermes_uid }}"
+    group: "{{ hermes_gid }}"
+    mode: "0640"
+  notify: restart timothy


### PR DESCRIPTION
## Summary
- `hermes config set` runs via `docker exec` as root, writes config.yaml owned root:root mode 640
- Container user (uid 1000) can't read it → falls back to default config, ignores model settings
- Add task to chown config.yaml to hermes_uid:hermes_gid after configuration