### PR TITLE
security: harden OCI and Timothy network perimeter

### DIFF
--- a/cloud/oci/ai-inference/ansible/roles/oci_ollama/tasks/main.yml
+++ b/cloud/oci/ai-inference/ansible/roles/oci_ollama/tasks/main.yml
@@ -153,3 +153,48 @@
       model: "{{ item.name }}"
   loop: "{{ (ollama_tags.content | from_json).models }}"
   when: item.name != ollama_model
+
+# ── Firewall ───────────────────────────────────────────────────────────────────
+- name: Ensure UFW is installed
+  ansible.builtin.apt:
+    name:
+      - ufw
+      - iptables-persistent
+    state: present
+
+- name: Configure UFW defaults
+  community.general.ufw:
+    direction: "{{ item.direction }}"
+    policy: "{{ item.policy }}"
+  loop:
+    - { direction: incoming, policy: deny }
+    - { direction: outgoing, policy: allow }
+
+- name: Allow all traffic on Tailscale interface
+  community.general.ufw:
+    rule: allow
+    interface: tailscale0
+    direction: in
+
+- name: Allow Tailscale WireGuard UDP
+  community.general.ufw:
+    rule: allow
+    port: "41641"
+    proto: udp
+
+- name: Allow Tailscale DERP relay HTTPS
+  community.general.ufw:
+    rule: allow
+    port: "443"
+    proto: tcp
+
+- name: Enable UFW
+  community.general.ufw:
+    state: enabled
+
+- name: Flush OCI default permissive iptables rules
+  ansible.builtin.shell: |
+    iptables -F INPUT
+    iptables -F FORWARD
+    netfilter-persistent save
+  changed_when: false

--- a/cloud/oci/ai-inference/terraform/main.tf
+++ b/cloud/oci/ai-inference/terraform/main.tf
@@ -34,8 +34,7 @@ resource "oci_core_route_table" "public" {
 }
 
 # Minimal ingress: Tailscale direct UDP + HTTPS for Tailscale DERP fallback.
-# SSH (22) intentionally omitted — access via Tailscale only post-bootstrap.
-# TEMP: SSH open for diagnostics — remove once Tailscale is confirmed connected.
+# All other access (SSH, Ollama, node-exporter) is via Tailscale only.
 resource "oci_core_security_list" "ai_inference" {
   compartment_id = var.compartment_ocid
   vcn_id         = oci_core_vcn.ai_inference.id
@@ -70,16 +69,6 @@ resource "oci_core_security_list" "ai_inference" {
     }
   }
 
-  # TEMP: SSH for diagnostics — remove after Tailscale confirmed connected
-  ingress_security_rules {
-    protocol  = "6" # TCP
-    source    = "0.0.0.0/0"
-    stateless = false
-    tcp_options {
-      min = 22
-      max = 22
-    }
-  }
 }
 
 resource "oci_core_subnet" "public" {

--- a/roles/timothy/templates/compose.yml.j2
+++ b/roles/timothy/templates/compose.yml.j2
@@ -24,6 +24,6 @@ services:
     environment:
       HERMES_UID: "{{ hermes_uid }}"
       HERMES_GID: "{{ hermes_gid }}"
-    command: ["dashboard", "--host", "0.0.0.0", "--no-open", "--insecure"]
+    command: ["dashboard", "--host", "{{ ansible_host }}", "--no-open", "--insecure"]
     depends_on:
       - gateway


### PR DESCRIPTION
## Summary
- **OCI security list**: remove SSH port 22 ingress (TEMP rule, Tailscale confirmed working)
- **OCI Ansible role**: install + configure UFW if missing (cloud-init failures leave host without firewall); deny all except tailscale0, WireGuard, DERP
- **Timothy dashboard**: bind to LAN IP instead of 0.0.0.0 — prevents bypassing Caddy/Tinyauth