### PR TITLE
fix(oci): remove iptables flush after UFW enable

### DIFF
--- a/cloud/oci/ai-inference/ansible/roles/oci_ollama/tasks/main.yml
+++ b/cloud/oci/ai-inference/ansible/roles/oci_ollama/tasks/main.yml
@@ -157,9 +157,7 @@
 # ── Firewall ───────────────────────────────────────────────────────────────────
 - name: Ensure UFW is installed
   ansible.builtin.apt:
-    name:
-      - ufw
-      - iptables-persistent
+    name: ufw
     state: present
 
 - name: Configure UFW defaults
@@ -191,10 +189,3 @@
 - name: Enable UFW
   community.general.ufw:
     state: enabled
-
-- name: Flush OCI default permissive iptables rules
-  ansible.builtin.shell: |
-    iptables -F INPUT
-    iptables -F FORWARD
-    netfilter-persistent save
-  changed_when: false

--- a/cloud/oci/ai-inference/terraform/files/cloud-init.yml.tftpl
+++ b/cloud/oci/ai-inference/terraform/files/cloud-init.yml.tftpl
@@ -10,7 +10,6 @@ package_upgrade: true
 packages:
   - curl
   - ufw
-  - iptables-persistent
   - prometheus-node-exporter
   - ca-certificates
   - gnupg
@@ -128,10 +127,5 @@ runcmd:
   - ufw allow 443/tcp comment 'Tailscale DERP relay'
   - ufw --force enable
 
-  # ── Flush OCI default iptables rules ───────────────────────────────────────
-  # OCI Ubuntu images ship with permissive iptables ACCEPT rules that would
-  # bypass UFW. Flush them AFTER UFW is enabled so there is no open window.
-  # iptables-persistent (installed above) ensures UFW rules survive reboots.
-  - iptables -F INPUT
-  - iptables -F FORWARD
-  - netfilter-persistent save
+  # UFW manages iptables rules directly — no manual flush needed.
+  # Enabling UFW inserts its FORWARD/INPUT chains ahead of any existing rules.


### PR DESCRIPTION
## Summary
- `iptables -F INPUT` after `ufw --force enable` flushes UFW's own rules including the tailscale0 allow rule
- This severs Tailscale connectivity and locks out the instance
- UFW manages iptables itself — no manual flush needed; it inserts rules at chain head
- Also remove `iptables-persistent` package (unused, UFW handles persistence)