### PR TITLE
fix(caddy): rewrite Host header for timothy dashboard proxy

### DIFF
--- a/roles/caddy/templates/Caddyfile.j2
+++ b/roles/caddy/templates/Caddyfile.j2
@@ -114,5 +114,7 @@ http://dns2.mol.la, dns2.mol.la {
 # Timothy — Hermes AI agent dashboard (protected by Tinyauth)
 http://timothy.mol.la, timothy.mol.la {
     import protected
-    reverse_proxy {{ hostvars['timothy'].ansible_host }}:9119
+    reverse_proxy {{ hostvars['timothy'].ansible_host }}:9119 {
+        header_up Host {upstream_hostport}
+    }
 }


### PR DESCRIPTION
## Summary
- Hermes dashboard binds to `192.168.178.125:9119` and validates `Host` matches the bound address
- Caddy was forwarding `Host: timothy.mol.la` → Hermes rejected with "Invalid Host header"
- Added `header_up Host {upstream_hostport}` to rewrite to `192.168.178.125:9119`