### PR TITLE
feat(ollama): create qwen3:8b-64k model with 65K context via Modelfile

### DIFF
--- a/cloud/oci/ai-inference/ansible/roles/oci_ollama/defaults/main.yml
+++ b/cloud/oci/ai-inference/ansible/roles/oci_ollama/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 ollama_version: "v0.23.2"
-ollama_model: "qwen3:8b"
+ollama_base_model: "qwen3:8b"
+ollama_model: "qwen3:8b-64k"
+ollama_num_ctx: 65536
 ollama_host: "0.0.0.0:11434"
 ollama_keep_alive: "10m"
 ollama_max_loaded_models: 1

--- a/cloud/oci/ai-inference/ansible/roles/oci_ollama/tasks/main.yml
+++ b/cloud/oci/ai-inference/ansible/roles/oci_ollama/tasks/main.yml
@@ -126,16 +126,34 @@
   loop: "{{ (ollama_ps.content | from_json).models }}"
   when: (ollama_ps.content | from_json).models | length > 0
 
-- name: Pull target model
+- name: Pull base model
   ansible.builtin.uri:
     url: http://127.0.0.1:11434/api/pull
     method: POST
     body_format: json
     body:
-      model: "{{ ollama_model }}"
+      model: "{{ ollama_base_model }}"
     timeout: 3600
   register: pull_result
   changed_when: false
+
+- name: Write Modelfile for extended context model
+  ansible.builtin.copy:
+    dest: /tmp/Modelfile
+    mode: "0644"
+    content: |
+      FROM {{ ollama_base_model }}
+      PARAMETER num_ctx {{ ollama_num_ctx }}
+
+- name: Create extended context model
+  ansible.builtin.command: >
+    /usr/local/bin/ollama create {{ ollama_model }} -f /tmp/Modelfile
+  changed_when: true
+
+- name: Remove Modelfile
+  ansible.builtin.file:
+    path: /tmp/Modelfile
+    state: absent
 
 - name: Get all local models
   ansible.builtin.uri:
@@ -144,7 +162,7 @@
     return_content: true
   register: ollama_tags
 
-- name: Remove models that are not the target
+- name: Remove models that are not the target or base
   ansible.builtin.uri:
     url: http://127.0.0.1:11434/api/delete
     method: DELETE
@@ -152,7 +170,7 @@
     body:
       model: "{{ item.name }}"
   loop: "{{ (ollama_tags.content | from_json).models }}"
-  when: item.name != ollama_model
+  when: item.name != ollama_model and item.name != ollama_base_model
 
 # ── Firewall ───────────────────────────────────────────────────────────────────
 - name: Ensure UFW is installed

--- a/roles/timothy/defaults/main.yml
+++ b/roles/timothy/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 timothy_vault_secret_path: "kv/homelab/data/timothy"
 hermes_image: "nousresearch/hermes-agent:latest"
-hermes_model: "qwen3:8b"
+hermes_model: "qwen3:8b-64k"
 hermes_data_dir: "/opt/hermes/data"
 hermes_uid: 1000
 hermes_gid: 1000

--- a/roles/timothy/tasks/main.yml
+++ b/roles/timothy/tasks/main.yml
@@ -59,6 +59,7 @@
     - { key: "model.provider", value: "custom" }
     - { key: "model.default", value: "{{ hermes_model }}" }
     - { key: "model.base_url", value: "{{ hermes_ollama_base_url }}/v1" }
+    - { key: "model.context_length", value: "65536" }
   changed_when: false
   notify: restart timothy
 


### PR DESCRIPTION
## Summary
- qwen3:8b native context (40K) is below Hermes Agent's 64K minimum — bot errors on every message
- OCI Ansible role now pulls `qwen3:8b` as base, then creates `qwen3:8b-64k` via Modelfile with `num_ctx 65536`
- Cleanup task updated to preserve both base and derived model
- Timothy `hermes_model` updated to `qwen3:8b-64k`; `model.context_length 65536` added to hermes config set

## Deploy order
1. Trigger `oci-ai-inference.yml` with `action=deploy` — creates the extended model on OCI
2. Run `./lab deploy timothy` — points Hermes at `qwen3:8b-64k`

## Test plan
- [ ] Telegram bot responds without context length error
- [ ] `ollama list` on OCI shows `qwen3:8b-64k`