### PR TITLE
feat(timothy): manage Telegram bot token via Vault

### DIFF
--- a/roles/timothy/defaults/main.yml
+++ b/roles/timothy/defaults/main.yml
@@ -2,6 +2,7 @@
 timothy_vault_secret_path: "kv/homelab/data/timothy"
 hermes_image: "nousresearch/hermes-agent:latest"
 hermes_model: "qwen3:8b-64k"
+hermes_telegram_allowed_users: "5177075152"
 hermes_data_dir: "/opt/hermes/data"
 hermes_uid: 1000
 hermes_gid: 1000

--- a/roles/timothy/defaults/main.yml
+++ b/roles/timothy/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
 timothy_vault_secret_path: "kv/homelab/data/timothy"
 hermes_image: "nousresearch/hermes-agent:latest"
-hermes_model: "qwen3:8b-64k"
+hermes_model: "glm-4-flash"
+hermes_model_provider: "glm"
 hermes_telegram_allowed_users: "5177075152"
 hermes_data_dir: "/opt/hermes/data"
 hermes_uid: 1000

--- a/roles/timothy/tasks/main.yml
+++ b/roles/timothy/tasks/main.yml
@@ -15,6 +15,7 @@
   ansible.builtin.set_fact:
     hermes_api_server_key: "{{ timothy_vault.data.data.data.api_server_key }}"
     hermes_ollama_base_url: "{{ timothy_vault.data.data.data.ollama_base_url }}"
+    hermes_telegram_bot_token: "{{ timothy_vault.data.data.data.telegram_bot_token }}"
   no_log: true
 
 - name: Create Hermes data directory
@@ -60,6 +61,8 @@
     - { key: "model.default", value: "{{ hermes_model }}" }
     - { key: "model.base_url", value: "{{ hermes_ollama_base_url }}/v1" }
     - { key: "model.context_length", value: "65536" }
+    - { key: "TELEGRAM_BOT_TOKEN", value: "{{ hermes_telegram_bot_token }}" }
+    - { key: "TELEGRAM_ALLOWED_USERS", value: "{{ hermes_telegram_allowed_users }}" }
   changed_when: false
   notify: restart timothy
 

--- a/roles/timothy/tasks/main.yml
+++ b/roles/timothy/tasks/main.yml
@@ -58,7 +58,7 @@
     docker exec timothy-gateway-{{ inventory_hostname }}
     /opt/hermes/.venv/bin/hermes config set {{ item.key }} {{ item.value }}
   loop:
-    - { key: "model.provider", value: "custom" }
+    - { key: "model.provider", value: "{{ hermes_model_provider }}" }
     - { key: "model.default", value: "{{ hermes_model }}" }
     - { key: "model.base_url", value: "{{ hermes_ollama_base_url }}/v1" }
     - { key: "model.context_length", value: "65536" }

--- a/roles/timothy/tasks/main.yml
+++ b/roles/timothy/tasks/main.yml
@@ -61,6 +61,7 @@
     - { key: "model.default", value: "{{ hermes_model }}" }
     - { key: "model.base_url", value: "{{ hermes_ollama_base_url }}/v1" }
     - { key: "model.context_length", value: "65536" }
+    - { key: "auxiliary.compression.context_length", value: "65536" }
     - { key: "TELEGRAM_BOT_TOKEN", value: "{{ hermes_telegram_bot_token }}" }
     - { key: "TELEGRAM_ALLOWED_USERS", value: "{{ hermes_telegram_allowed_users }}" }
   changed_when: false

--- a/roles/timothy/tasks/main.yml
+++ b/roles/timothy/tasks/main.yml
@@ -16,6 +16,7 @@
     hermes_api_server_key: "{{ timothy_vault.data.data.data.api_server_key }}"
     hermes_ollama_base_url: "{{ timothy_vault.data.data.data.ollama_base_url }}"
     hermes_telegram_bot_token: "{{ timothy_vault.data.data.data.telegram_bot_token }}"
+    hermes_glm_api_key: "{{ timothy_vault.data.data.data.glm_api_key }}"
   no_log: true
 
 - name: Create Hermes data directory
@@ -64,6 +65,7 @@
     - { key: "auxiliary.compression.context_length", value: "65536" }
     - { key: "TELEGRAM_BOT_TOKEN", value: "{{ hermes_telegram_bot_token }}" }
     - { key: "TELEGRAM_ALLOWED_USERS", value: "{{ hermes_telegram_allowed_users }}" }
+    - { key: "GLM_API_KEY", value: "{{ hermes_glm_api_key }}" }
   changed_when: false
   notify: restart timothy
 


### PR DESCRIPTION
## Summary
- `TELEGRAM_BOT_TOKEN` was manually set and lost on every redeploy
- Now read from Vault (`kv/homelab/data/timothy.telegram_bot_token`) and applied via `hermes config set`
- `TELEGRAM_ALLOWED_USERS` extracted to a var in defaults

## Prerequisites
- Vault key `telegram_bot_token` must exist at `kv/homelab/data/timothy` (already added)

## Test plan
- [ ] `./lab deploy timothy` — Telegram bot token set without manual intervention
- [ ] Bot responds on Telegram after deploy