### PR TITLE
fix(timothy): update GLM model to glm-4.5-air

### DIFF
--- a/roles/timothy/defaults/main.yml
+++ b/roles/timothy/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 timothy_vault_secret_path: "kv/homelab/data/timothy"
 hermes_image: "nousresearch/hermes-agent:latest"
-hermes_model: "glm-4-flash"
+hermes_model: "glm-4.5-air"
 hermes_model_provider: "glm"
 hermes_telegram_allowed_users: "5177075152"
 hermes_data_dir: "/opt/hermes/data"


### PR DESCRIPTION
## Summary
- `glm-4-flash` returns error 1211 (unknown model) — model is on z.ai not bigmodel.cn
- Available models on the account are `glm-4.5`, `glm-4.5-air`, etc. (z-ai family)
- Switching default to `glm-4.5-air` (lite/air tier)