### PR TITLE
chore(jellyfin): increase lxc root disk to 30gb

### DIFF
--- a/inventory/group_vars/all/lxc.yml
+++ b/inventory/group_vars/all/lxc.yml
@@ -75,7 +75,7 @@ proxmox_containers:
     unprivileged: 1
     cores: 2
     memory: 4096
-    disk: "local-lvm:10"
+    disk: "local-lvm:30"
     mount_volumes:
       - id: mp0
         host_path: "{{ jellyfin_media_storage_host_path }}"


### PR DESCRIPTION
Root filesystem was full at 10GB, blocking Docker restarts.