### PR TITLE
chore(humaun): increase lxc memory to 8gb

### DIFF
--- a/inventory/group_vars/all/lxc.yml
+++ b/inventory/group_vars/all/lxc.yml
@@ -118,7 +118,7 @@ proxmox_containers:
     description: "Humaun"
     unprivileged: 1
     cores: 2
-    memory: 4096
+    memory: 8192
     disk: "local-lvm:30"
   - vmid: 253
     hostname: adguard-primary


### PR DESCRIPTION
## Summary
- Raise Humaun LXC (vmid 252) memory from 4GB to 8GB in `inventory/group_vars/all/lxc.yml`
- Aligns IaC with live Proxmox config already applied via `pct set 252 -memory 8192`

## Test plan
- [x] Verified on Proxmox: `pct config 252` shows `memory: 8192`
- [x] Verified in container: `free -h` reports 8.0Gi total

Made with [Cursor](https://cursor.com)