### PR TITLE
feat: add navidrome music server

### DIFF
--- a/deployments/deploy_navidrome.yml
+++ b/deployments/deploy_navidrome.yml
@@ -1,0 +1,11 @@
+---
+# Deploy Navidrome music server (Docker on LXC).
+# Prereq: LXC must have media-storage bind-mounted (see lxc.yml).
+# Create a 'music' (or other) subdirectory under the media storage on the Proxmox host
+# before deploying, so it appears at navidrome_music_path inside the container.
+# Usage: ansible-playbook deployments/deploy_navidrome.yml
+- name: Deploy Navidrome
+  hosts: navidrome_host
+  become: true
+  roles:
+    - navidrome

--- a/inventory/group_vars/all/lxc.yml
+++ b/inventory/group_vars/all/lxc.yml
@@ -104,6 +104,18 @@ proxmox_containers:
       - id: mp0
         host_path: "{{ jellyfin_media_storage_host_path }}"
         mountpoint: /media
+  - vmid: 143
+    hostname: navidrome
+    ip: "192.168.178.143/24"
+    description: "Navidrome music server"
+    unprivileged: 1
+    cores: 2
+    memory: 2048
+    disk: "local-lvm:15"
+    mount_volumes:
+      - id: mp0
+        host_path: "{{ jellyfin_media_storage_host_path }}"
+        mountpoint: /media
   - vmid: 250
     hostname: dash
     ip: "192.168.178.250/24"

--- a/inventory/group_vars/navidrome_host.yml
+++ b/inventory/group_vars/navidrome_host.yml
@@ -1,0 +1,4 @@
+---
+# Navidrome LXC at 192.168.178.143.
+# navidrome_music_path: /media/music   # default; subdirectory must exist under the media storage bind mount.
+ansible_user: root

--- a/inventory/hosts
+++ b/inventory/hosts
@@ -28,6 +28,10 @@ arr ansible_host=192.168.178.141
 [immich_host]
 immich ansible_host=192.168.178.142
 
+# Navidrome music server
+[navidrome_host]
+navidrome ansible_host=192.168.178.143
+
 # Monitoring
 [monitoring_host]
 monitoring ansible_host=192.168.178.124
@@ -101,6 +105,7 @@ adguard_secondary_host
 jellyfin_host
 arr_host
 immich_host
+navidrome_host
 dash_host
 timothy_host
 humaun_host

--- a/lab
+++ b/lab
@@ -131,6 +131,7 @@ cmd_deploy() {
     [jellyfin]="Jellyfin media server"
     [arr]="*arr stack"
     [immich]="Immich photo/video backup"
+    [navidrome]="Navidrome music server"
     [tailscale]="Tailscale (all hosts)"
     [timothy]="Timothy (Hermes AI agent)"
   )
@@ -138,7 +139,7 @@ cmd_deploy() {
   if [[ -z "$service" || -z "${SERVICE_LABELS[$service]+_}" ]]; then
     _header "Deploy — available services"
     for svc in adguard caddy pocketid vault postgresql mysql redis mongodb \
-                monitoring node-exporter pve-exporter jellyfin arr immich \
+                monitoring node-exporter pve-exporter jellyfin arr immich navidrome \
                 tailscale timothy; do
       printf "    ${CYAN}%-18s${RESET} %s\n" "$svc" "${SERVICE_LABELS[$svc]}"
     done
@@ -179,6 +180,7 @@ cmd_deploy() {
     arr)           _run ansible-playbook "$DEPLOYMENTS_DIR/deploy_arr.yml" ;;
     immich)        _require_vars vault_auth_vars.yml
                    _run ansible-playbook "$DEPLOYMENTS_DIR/deploy_immich.yml" -e "@$VARS_DIR/vault_auth_vars.yml" ;;
+    navidrome)     _run ansible-playbook "$DEPLOYMENTS_DIR/deploy_navidrome.yml" ;;
     tailscale)     _require_vars vault_auth_vars.yml
                    _run ansible-playbook "$DEPLOYMENTS_DIR/deploy_tailscale.yml" -e "@$VARS_DIR/vault_auth_vars.yml" ;;
     timothy)       _require_vars vault_auth_vars.yml
@@ -197,6 +199,7 @@ cmd_upgrade() {
     [pocketid]="192.168.178.122 /opt/compose/pocketid-pocketid"
     [jellyfin]="192.168.178.140 /opt/compose/jellyfin-jellyfin"
     [arr]="192.168.178.141 /opt/compose/arr-arr"
+    [navidrome]="192.168.178.143 /opt/compose/navidrome-navidrome"
     [timothy]="192.168.178.125 /opt/compose/timothy-timothy"
   )
 

--- a/roles/caddy/templates/Caddyfile.j2
+++ b/roles/caddy/templates/Caddyfile.j2
@@ -65,6 +65,11 @@ http://media.mol.la, media.mol.la {
     reverse_proxy {{ hostvars['jellyfin'].ansible_host }}:8096
 }
 
+# Navidrome — music server (music.mol.la), public; auth via Navidrome users only
+http://music.mol.la, music.mol.la {
+    reverse_proxy {{ hostvars['navidrome'].ansible_host }}:4533
+}
+
 # *arr stack — SABnzbd, Prowlarr, Radarr, Sonarr, Bazarr, Jellyseerr (arr LXC)
 # Backend: arr_lxc_ip from group_vars/caddy_host or role defaults
 http://sabnzbd.mol.la, sabnzbd.mol.la {

--- a/roles/navidrome/defaults/main.yml
+++ b/roles/navidrome/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+# Navidrome music server — Docker on LXC.
+# Ensure the LXC has media-storage bind-mounted (e.g. Proxmox mp0=...,/media).
+# Music collection should live in a subdirectory (default /media/music).
+navidrome_image: deluan/navidrome:latest
+navidrome_port: 4533
+# Path inside the LXC to your music collection (must exist; bind from Proxmox media-storage).
+navidrome_music_path: /media/music
+navidrome_tz: "Europe/Amsterdam"
+# Optional: run the container as a specific uid/gid to match media file ownership.
+# navidrome_uid: 1000
+# navidrome_gid: 1000

--- a/roles/navidrome/handlers/main.yml
+++ b/roles/navidrome/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart Navidrome
+  community.docker.docker_compose_v2:
+    project_src: "/opt/compose/navidrome-{{ inventory_hostname }}"
+    state: present

--- a/roles/navidrome/tasks/main.yml
+++ b/roles/navidrome/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+# Navidrome music server in Docker. Requires LXC to have media-storage bind-mounted
+# and a music collection directory (e.g. /media/music) visible inside the LXC.
+- name: Ensure compose project directory exists
+  ansible.builtin.file:
+    path: "/opt/compose/navidrome-{{ inventory_hostname }}"
+    state: directory
+    mode: '0755'
+
+- name: Check music path exists (bind-mount from Proxmox media-storage before deploy)
+  ansible.builtin.stat:
+    path: "{{ navidrome_music_path }}"
+  register: music_path_stat
+
+- name: Fail if music path is missing
+  ansible.builtin.fail:
+    msg: "Music path '{{ navidrome_music_path }}' must exist on the LXC. Create the directory on the Proxmox host under the media storage (e.g. mkdir -p /mnt/media/music) so it is visible inside the container after the bind mount."
+  when: not music_path_stat.stat.exists or not music_path_stat.stat.isdir
+
+- name: Deploy Navidrome compose file
+  ansible.builtin.template:
+    src: compose.yml.j2
+    dest: "/opt/compose/navidrome-{{ inventory_hostname }}/compose.yml"
+    mode: '0644'
+  notify: Restart Navidrome
+
+- name: Start Navidrome with Docker Compose
+  community.docker.docker_compose_v2:
+    project_src: "/opt/compose/navidrome-{{ inventory_hostname }}"
+    state: present
+    pull: always

--- a/roles/navidrome/templates/compose.yml.j2
+++ b/roles/navidrome/templates/compose.yml.j2
@@ -1,0 +1,25 @@
+# Navidrome music server.
+# Music collection must be bind-mounted into the LXC (see navidrome_music_path).
+services:
+  navidrome:
+    image: {{ navidrome_image }}
+    container_name: navidrome-{{ inventory_hostname }}
+    restart: unless-stopped
+    ports:
+      - "{{ navidrome_port }}:4533"
+    volumes:
+      - navidrome_data:/data
+      - "{{ navidrome_music_path }}:/music:ro"
+    environment:
+      TZ: "{{ navidrome_tz }}"
+      # Additional options (uncomment and set as needed):
+      # ND_LOGLEVEL: info
+      # ND_SESSIONTIMEOUT: 24h
+      # ND_MUSICFOLDER: /music
+    # Optional: run as specific uid/gid to match media ownership (set in group_vars if needed).
+{% if navidrome_uid is defined and navidrome_gid is defined %}
+    user: "{{ navidrome_uid }}:{{ navidrome_gid }}"
+{% endif %}
+
+volumes:
+  navidrome_data:


### PR DESCRIPTION
Add Navidrome for self-hosted music streaming with strong iOS app support via the Subsonic/OpenSubsonic API.

This enables clients like Amperfy, play:Sub, Sonora, etc. on iOS (CarPlay, offline, etc.).

- LXC 143 (192.168.178.143) with media mount
- New role, playbook, inventory, Caddy route (music.mol.la)
- Integrated with ./lab deploy/upgrade
- Follows patterns from Jellyfin and *arr services
- No Vault required

SSH/git access on ansible host was fixed separately to support this.