### PR TITLE
feat: improve caddy build caching and avoid unnecessary rebuilds

### DIFF
--- a/inventory/group_vars/all/lxc.yml
+++ b/inventory/group_vars/all/lxc.yml
@@ -16,6 +16,7 @@ proxmox_containers:
     ip: "192.168.178.121/24"
     description: "Caddy Reverse Proxy & Cloudflare Tunnel"
     unprivileged: 1
+    disk: "local-lvm:20"
   - vmid: 122
     hostname: pocketid
     ip: "192.168.178.122/24"

--- a/roles/caddy/files/Dockerfile
+++ b/roles/caddy/files/Dockerfile
@@ -1,6 +1,10 @@
-# Caddy with Cloudflare DNS module for ACME DNS-01 challenge
+# syntax=docker/dockerfile:1.4
+# Caddy with Cloudflare DNS module for ACME DNS-01 challenge.
+# Use cache mounts to reduce repeated downloads and temp space usage during xcaddy builds.
 FROM caddy:builder AS builder
-RUN xcaddy build --with github.com/caddy-dns/cloudflare
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    xcaddy build --with github.com/caddy-dns/cloudflare
 
 FROM caddy:latest
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -36,6 +36,7 @@
     src: Dockerfile
     dest: "/opt/compose/caddy-{{ inventory_hostname }}/Dockerfile"
     mode: '0644'
+  register: caddy_dockerfile
 
 - name: Deploy Caddy compose file
   ansible.builtin.template:
@@ -52,8 +53,18 @@
     mode: '0644'
   notify: Restart Caddy service
 
+- name: Build custom Caddy image (only when Dockerfile changes)
+  community.docker.docker_image:
+    name: caddy-cloudflare-{{ inventory_hostname }}
+    build:
+      path: "/opt/compose/caddy-{{ inventory_hostname }}"
+      dockerfile: Dockerfile
+    source: build
+  when: caddy_dockerfile.changed
+  notify: Restart Caddy service
+
 - name: Start Caddy and Cloudflare Tunnel with Docker Compose
   community.docker.docker_compose_v2:
     project_src: "/opt/compose/caddy-{{ inventory_hostname }}"
     state: present
-    build: always
+    build: false


### PR DESCRIPTION
Improve Caddy's custom image build to be less painful on disk:

- Use Docker cache mounts in the xcaddy build step.
- Only trigger the expensive build when the Dockerfile actually changes (Caddyfile updates no longer force full rebuild).
- Set explicit non-always build in compose.

Combined with the 20G disk allocation for the caddy LXC, this should eliminate most 'no space left on device' errors during deploys.

The Caddyfile route for music.mol.la and Cloudflare plugin remain unchanged.