### PR TITLE
fix: use docker cli for caddy build to avoid python requests dep

### DIFF
--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -54,12 +54,12 @@
   notify: Restart Caddy service
 
 - name: Build custom Caddy image (only when Dockerfile changes)
-  community.docker.docker_image:
-    name: caddy-cloudflare-{{ inventory_hostname }}
-    build:
-      path: "/opt/compose/caddy-{{ inventory_hostname }}"
-      dockerfile: Dockerfile
-    source: build
+  ansible.builtin.command:
+    cmd: >
+      docker build
+      -t caddy-cloudflare-{{ inventory_hostname }}
+      -f /opt/compose/caddy-{{ inventory_hostname }}/Dockerfile
+      /opt/compose/caddy-{{ inventory_hostname }}
   when: caddy_dockerfile.changed
   notify: Restart Caddy service
 


### PR DESCRIPTION
The docker_image module requires the 'requests' Python library on the caddy LXC, which isn't present.

Switch to a simple 'docker build' command (which is already available) when the Dockerfile changes.

This keeps the 'build only on change' behavior without extra dependencies on the minimal caddy container.