### PR TITLE
fix: correct build param for caddy docker_compose

### DIFF
--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -67,4 +67,4 @@
   community.docker.docker_compose_v2:
     project_src: "/opt/compose/caddy-{{ inventory_hostname }}"
     state: present
-    build: false
+    build: never


### PR DESCRIPTION
Fix invalid 'build: false' value.