### PR TITLE
feat: integrate navidrome into prometheus + grafana

### DIFF
--- a/roles/monitoring/defaults/main.yml
+++ b/roles/monitoring/defaults/main.yml
@@ -20,6 +20,9 @@ prometheus_immich_targets:
   - { addr: "{{ prometheus_immich_host | default('192.168.178.142') }}:8081", name: "immich-api" }
   - { addr: "{{ prometheus_immich_host | default('192.168.178.142') }}:8082", name: "immich-microservices" }
 
+prometheus_navidrome_targets:
+  - { addr: "{{ prometheus_navidrome_host | default('192.168.178.143') }}:4533", name: "navidrome" }
+
 # PVE exporter
 pve_exporter_target: "192.168.178.110"
 pve_exporter_scrape_addr: "192.168.178.110:9221"
@@ -44,3 +47,7 @@ grafana_community_dashboards:
   - id: 1860
     revision: 37
     name: node-exporter-full
+  # Navidrome dashboard (metrics on /metrics)
+  - id: 15290
+    revision: 2
+    name: navidrome

--- a/roles/monitoring/templates/prometheus.yml.j2
+++ b/roles/monitoring/templates/prometheus.yml.j2
@@ -28,6 +28,14 @@ scrape_configs:
           instance: "{{ node.name }}"
 {% endfor %}
 
+  - job_name: "navidrome"
+    static_configs:
+{% for node in prometheus_navidrome_targets | default([]) %}
+      - targets: ["{{ node.addr }}"]
+        labels:
+          instance: "{{ node.name }}"
+{% endfor %}
+
   - job_name: "pve"
     scrape_interval: 30s
     scrape_timeout: 30s

--- a/roles/navidrome/defaults/main.yml
+++ b/roles/navidrome/defaults/main.yml
@@ -7,6 +7,10 @@ navidrome_port: 4533
 # Path inside the LXC to your music collection (must exist; bind from Proxmox media-storage).
 navidrome_music_path: /media/music
 navidrome_tz: "Europe/Amsterdam"
+
+# Prometheus metrics (exposed on the main port at /metrics)
+navidrome_prometheus_enabled: true
+
 # Optional: run the container as a specific uid/gid to match media file ownership.
 # navidrome_uid: 1000
 # navidrome_gid: 1000

--- a/roles/navidrome/templates/compose.yml.j2
+++ b/roles/navidrome/templates/compose.yml.j2
@@ -12,6 +12,9 @@ services:
       - "{{ navidrome_music_path }}:/music:ro"
     environment:
       TZ: "{{ navidrome_tz }}"
+{% if navidrome_prometheus_enabled | default(false) %}
+      ND_PROMETHEUS_ENABLED: "true"
+{% endif %}
       # Additional options (uncomment and set as needed):
       # ND_LOGLEVEL: info
       # ND_SESSIONTIMEOUT: 24h


### PR DESCRIPTION
Add Navidrome to the monitoring stack:

- Enable ND_PROMETHEUS_ENABLED in the Navidrome compose
- Add scrape config for navidrome:4533/metrics in Prometheus
- Provision a Navidrome Grafana dashboard

Requires re-deploy of navidrome (for env var) and monitoring.