### PR TITLE
docs: update architecture tables and lists for navidrome

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ vars/                    → runtime secrets/config (gitignored); *.example file
 | 192.168.178.140 | Jellyfin                          | Docker Compose |
 | 192.168.178.141 | *arr stack                        | Docker Compose |
 | 192.168.178.142 | Immich                            | Docker Compose |
+| 192.168.178.143 | Navidrome (music)                 | Docker Compose |
 | 192.168.178.250 | Dash (Dashboard)                  | Docker Compose |
 | 192.168.178.252 | Humaun                            | Docker Compose |
 | 192.168.178.253 | AdGuard Primary                   | Docker Compose |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Proxmox VE (192.168.178.110)
 ├── LXC 140  Jellyfin (media)
 ├── LXC 141  ARR stack (Radarr, Sonarr, SABnzbd, …)
 ├── LXC 142  Immich (photo/video backup)
+├── LXC 143  Navidrome (music)
 ├── LXC 250  Dash (Dashboard)
 ├── LXC 252  Humaun
 ├── LXC 253  AdGuard Home Primary (DNS + DHCP)
@@ -168,9 +169,10 @@ Node exporter goes on all hosts first, then Prometheus + Grafana, then PVE expor
 ansible-playbook deployments/deploy_jellyfin.yml
 ansible-playbook deployments/deploy_arr.yml
 ansible-playbook deployments/deploy_immich.yml -e "@vars/vault_auth_vars.yml"
+ansible-playbook deployments/deploy_navidrome.yml
 ```
 
-Immich depends on PostgreSQL (with `pgvector`) and Redis being deployed first.
+Immich depends on PostgreSQL (with `pgvector`) and Redis being deployed first. Navidrome is standalone (needs media bind mount).
 
 ### 10. Timothy (Hermes AI agent)
 
@@ -205,6 +207,7 @@ PVE Exporter ─ Vault
 Jellyfin ──── (standalone, needs media bind mount)
 ARR ────────── (standalone, needs media bind mount)
 Immich ─────── Vault, PostgreSQL (pgvector), Redis
+Navidrome ──── (standalone, needs media bind mount)
 Timothy ─────── Vault, Tailscale → OCI Ollama (oci-ai-inference via MagicDNS)
 ```
 


### PR DESCRIPTION
Update README.md and CLAUDE.md to include Navidrome (LXC 143, music.mol.la) in:

- Architecture diagram
- Core infrastructure table
- Bootstrap / Applications section
- Service dependencies

Keeps documentation in sync with the added service, monitoring, and Caddy integration.