### PR TITLE
feat: add lidarr to arr stack for music collection

### DIFF
--- a/deployments/create_lxc.yml
+++ b/deployments/create_lxc.yml
@@ -40,6 +40,7 @@
         - downloads
         - movies
         - tv
+        - music
 
     - name: Validate bind mount definitions
       ansible.builtin.assert:

--- a/inventory/group_vars/arr_host.yml
+++ b/inventory/group_vars/arr_host.yml
@@ -1,6 +1,6 @@
 ---
 # ARR stack LXC at 192.168.178.141. Override media paths if mount differs.
-# Run *arr as root (0:0) so /movies, /tv, /downloads are writable (mount permission quirks in unprivileged LXC).
+# Run *arr as root (0:0) so /movies, /tv, /downloads, /music are writable (mount permission quirks in unprivileged LXC).
 arr_uid: 0
 arr_gid: 0
 ansible_user: root

--- a/inventory/group_vars/navidrome_host.yml
+++ b/inventory/group_vars/navidrome_host.yml
@@ -1,4 +1,4 @@
 ---
 # Navidrome LXC at 192.168.178.143.
-# navidrome_music_path: /media/music   # default; subdirectory must exist under the media storage bind mount.
+# navidrome_music_path: /media/libraries/music   # default; subdirectory must exist under the media storage bind mount (matches arr stack).
 ansible_user: root

--- a/roles/arr/defaults/main.yml
+++ b/roles/arr/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# *arr stack — SABnzbd, Prowlarr, Radarr, Sonarr, Bazarr, Seerr
+# *arr stack — SABnzbd, Prowlarr, Radarr, Sonarr, Lidarr, Bazarr, Seerr
 # Deploys in a single Docker Compose stack inside an LXC.
 
 # Docker images (linuxserver.io)
@@ -9,6 +9,7 @@ arr_radarr_image: lscr.io/linuxserver/radarr:latest
 arr_sonarr_image: lscr.io/linuxserver/sonarr:latest
 arr_bazarr_image: lscr.io/linuxserver/bazarr:latest
 arr_seerr_image: ghcr.io/seerr-team/seerr:latest
+arr_lidarr_image: lscr.io/linuxserver/lidarr:latest
 
 # Ports
 arr_sabnzbd_port: 8080
@@ -17,6 +18,7 @@ arr_radarr_port: 7878
 arr_sonarr_port: 8989
 arr_bazarr_port: 6767
 arr_seerr_port: 5055
+arr_lidarr_port: 8686
 
 # User/Group IDs (PUID/PGID) — adjust to match media ownership on the host
 arr_uid: 1000
@@ -31,6 +33,7 @@ arr_media_path: /media
 arr_downloads_path: "{{ arr_media_path }}/libraries/downloads"
 arr_movies_path: "{{ arr_media_path }}/libraries/movies"
 arr_tv_path: "{{ arr_media_path }}/libraries/tv"
+arr_music_path: "{{ arr_media_path }}/libraries/music"
 
 # Config directory (local to LXC, not bind-mounted)
 arr_config_path: /opt/arrstack/config

--- a/roles/arr/tasks/main.yml
+++ b/roles/arr/tasks/main.yml
@@ -33,14 +33,15 @@
     - "{{ arr_downloads_path }}"
     - "{{ arr_movies_path }}"
     - "{{ arr_tv_path }}"
+    - "{{ arr_music_path }}"
 
 - name: Fail if media subdirectories are missing
   ansible.builtin.fail:
     msg: >-
       Media subdirs must exist on the host before deploy (bind mount may be read-only in LXC).
-      On the Proxmox host create: {{ arr_downloads_path }}, {{ arr_movies_path }}, {{ arr_tv_path }}
-      (e.g. mkdir -p /mnt/media/libraries/{downloads,movies,tv}) then re-run.
-  when: media_subdirs_stat.results | selectattr('stat.exists', 'equalto', true) | list | length != 3
+      On the Proxmox host create: {{ arr_downloads_path }}, {{ arr_movies_path }}, {{ arr_tv_path }}, {{ arr_music_path }}
+      (e.g. mkdir -p /mnt/media/libraries/{downloads,movies,tv,music}) then re-run.
+  when: media_subdirs_stat.results | selectattr('stat.exists', 'equalto', true) | list | length != 4
 
 - name: Deploy ARR stack compose file
   ansible.builtin.template:

--- a/roles/arr/templates/docker-compose.yml.j2
+++ b/roles/arr/templates/docker-compose.yml.j2
@@ -1,4 +1,4 @@
-# *arr stack — SABnzbd, Prowlarr, Radarr, Sonarr, Bazarr, Seerr
+# *arr stack — SABnzbd, Prowlarr, Radarr, Sonarr, Lidarr, Bazarr, Seerr
 # Media directories must be bind-mounted into the LXC from Proxmox (same as Jellyfin).
 services:
   # SABnzbd - Usenet downloader
@@ -62,6 +62,24 @@ services:
       - {{ arr_config_path }}/sonarr:/config
       - {{ arr_tv_path }}:/tv
       - {{ arr_downloads_path }}:/downloads
+    environment:
+      PUID: "{{ arr_uid }}"
+      PGID: "{{ arr_gid }}"
+      TZ: "{{ arr_tz }}"
+
+  # Lidarr - Music manager (for Navidrome library)
+  # Connect to Prowlarr for indexers and qBittorrent/SABnzbd for downloads.
+  # Root folder inside container: /music (maps to /media/libraries/music on host)
+  lidarr:
+    image: {{ arr_lidarr_image }}
+    container_name: lidarr-{{ inventory_hostname }}
+    restart: unless-stopped
+    ports:
+      - "{{ arr_lidarr_port }}:8686"
+    volumes:
+      - {{ arr_config_path }}/lidarr:/config
+      - {{ arr_downloads_path }}:/downloads
+      - {{ arr_music_path }}:/music
     environment:
       PUID: "{{ arr_uid }}"
       PGID: "{{ arr_gid }}"

--- a/roles/caddy/templates/Caddyfile.j2
+++ b/roles/caddy/templates/Caddyfile.j2
@@ -70,6 +70,12 @@ http://music.mol.la, music.mol.la {
     reverse_proxy {{ hostvars['navidrome'].ansible_host }}:4533
 }
 
+# Lidarr — music manager (lidarr.mol.la), protected
+http://lidarr.mol.la, lidarr.mol.la {
+    import protected
+    reverse_proxy {{ arr_lxc_ip }}:8686
+}
+
 # *arr stack — SABnzbd, Prowlarr, Radarr, Sonarr, Bazarr, Jellyseerr (arr LXC)
 # Backend: arr_lxc_ip from group_vars/caddy_host or role defaults
 http://sabnzbd.mol.la, sabnzbd.mol.la {

--- a/roles/navidrome/defaults/main.yml
+++ b/roles/navidrome/defaults/main.yml
@@ -1,11 +1,11 @@
 ---
 # Navidrome music server — Docker on LXC.
 # Ensure the LXC has media-storage bind-mounted (e.g. Proxmox mp0=...,/media).
-# Music collection should live in a subdirectory (default /media/music).
+# Music collection should live in a subdirectory (default /media/libraries/music to match arr stack).
 navidrome_image: deluan/navidrome:latest
 navidrome_port: 4533
 # Path inside the LXC to your music collection (must exist; bind from Proxmox media-storage).
-navidrome_music_path: /media/music
+navidrome_music_path: /media/libraries/music
 navidrome_tz: "Europe/Amsterdam"
 
 # Prometheus metrics (exposed on the main port at /metrics)


### PR DESCRIPTION
Add Lidarr to the *arr stack so music can be automatically collected and organized for Navidrome.

- Lidarr container added to arr compose (shares downloads and music library)
- Paths aligned to /media/libraries/music
- Caddy route for lidarr.mol.la (protected)
- Music dir creation in LXC setup

After merge, run ./lab deploy arr then ./lab deploy caddy