### PR TITLE
chore(versions): bump pinned services to latest available

### DIFF
--- a/roles/pocketid/defaults/main.yml
+++ b/roles/pocketid/defaults/main.yml
@@ -2,5 +2,5 @@
 # Vault path for PocketID secrets (pocketid_encryption_key, tinyauth_pocketid_client_id, tinyauth_pocketid_client_secret)
 pocketid_vault_secret_path: "kv/homelab/data/pocketid"
 
-pocketid_image: "ghcr.io/pocket-id/pocket-id:v2.6.2"
-tinyauth_image: "ghcr.io/steveiliop56/tinyauth:v4"
+pocketid_image: "ghcr.io/pocket-id/pocket-id:v2.9.0"
+tinyauth_image: "ghcr.io/steveiliop56/tinyauth:v5.0.7"

--- a/roles/pve_exporter/defaults/main.yml
+++ b/roles/pve_exporter/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-pve_exporter_version: "3.8.3"
+pve_exporter_version: "3.9.0"
 pve_exporter_port: 9221
 pve_exporter_venv: /opt/pve-exporter
 pve_exporter_config: /etc/prometheus/pve.yml

--- a/roles/vault/defaults/main.yml
+++ b/roles/vault/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-vault_version: "1.21.4"
+vault_version: "2.0.3"
 vault_listen_address: "0.0.0.0:8200"
 vault_data_dir: "/var/lib/vault/data"
 vault_config_dir: "/etc/vault.d"


### PR DESCRIPTION
- pocketid: v2.9.0
- tinyauth: v5.0.7
- pve-exporter: 3.9.0
- vault: 2.0.3 (major; review breaking changes in Vault 2.0 release notes)

Bump before redeploy to pull new binaries/images.