### PR TITLE
feat(vault): upgrade to 2.0.3 and complete auth fixes

### DIFF
--- a/roles/caddy/templates/Caddyfile.j2
+++ b/roles/caddy/templates/Caddyfile.j2
@@ -29,12 +29,20 @@ http://id.mol.la, id.mol.la {
 
     # Route Tinyauth traffic
     handle @tinyauth_paths {
-        reverse_proxy 192.168.178.122:1412
+        reverse_proxy 192.168.178.122:1412 {
+            header_up Host {host}
+            header_up X-Forwarded-Proto https
+            header_up X-Forwarded-Host {host}
+        }
     }
 
     # Route everything else to Pocket ID
     handle {
-        reverse_proxy 192.168.178.122:1411
+        reverse_proxy 192.168.178.122:1411 {
+            header_up Host {host}
+            header_up X-Forwarded-Proto https
+            header_up X-Forwarded-Host {host}
+        }
     }
 }
 

--- a/roles/pocketid/defaults/main.yml
+++ b/roles/pocketid/defaults/main.yml
@@ -2,5 +2,5 @@
 # Vault path for PocketID secrets (pocketid_encryption_key, tinyauth_pocketid_client_id, tinyauth_pocketid_client_secret)
 pocketid_vault_secret_path: "kv/homelab/data/pocketid"
 
-pocketid_image: "ghcr.io/pocket-id/pocket-id:v2.9.0"
+pocketid_image: "ghcr.io/pocket-id/pocket-id:v2.10.0"
 tinyauth_image: "ghcr.io/steveiliop56/tinyauth:v5.0.7"

--- a/roles/pocketid/templates/compose.yml.j2
+++ b/roles/pocketid/templates/compose.yml.j2
@@ -9,19 +9,19 @@ services:
     volumes:
       - tinyauth_data:/data
     environment:
-      APP_URL: "https://id.mol.la"
-      SECURE_COOKIE: "true"
-      OAUTH_AUTO_REDIRECT: "pocketid"
-      USERS: "{{ tinyauth_users | default('oauth_placeholder:$$2a$$10$$UdLYoJ5lgPsC0RKqYH/jMua7zIn0g9kPqWmhYayJYLaZQ/FTmH2/u') }}"
-      PROVIDERS_POCKETID_CLIENT_ID: "{{ tinyauth_pocketid_client_id }}"
-      PROVIDERS_POCKETID_CLIENT_SECRET: "{{ tinyauth_pocketid_client_secret }}"
-      PROVIDERS_POCKETID_AUTH_URL: "https://id.mol.la/authorize"
-      PROVIDERS_POCKETID_TOKEN_URL: "https://id.mol.la/api/oidc/token"
-      PROVIDERS_POCKETID_USER_INFO_URL: "https://id.mol.la/api/oidc/userinfo"
-      PROVIDERS_POCKETID_REDIRECT_URL: "https://id.mol.la/api/oauth/callback/pocketid"
-      PROVIDERS_POCKETID_SCOPES: "openid email profile groups"
-      PROVIDERS_POCKETID_NAME: "Pocket ID"
-      TRUSTED_PROXIES: "192.168.178.121,127.0.0.1,::1"
+      TINYAUTH_APPURL: "https://id.mol.la"
+      TINYAUTH_AUTH_SECURECOOKIE: "true"
+      TINYAUTH_OAUTH_AUTOREDIRECT: "pocketid"
+      TINYAUTH_AUTH_USERS: "{{ tinyauth_users | default('oauth_placeholder:$$2a$$10$$UdLYoJ5lgPsC0RKqYH/jMua7zIn0g9kPqWmhYayJYLaZQ/FTmH2/u') }}"
+      TINYAUTH_OAUTH_PROVIDERS_POCKETID_CLIENTID: "{{ tinyauth_pocketid_client_id }}"
+      TINYAUTH_OAUTH_PROVIDERS_POCKETID_CLIENTSECRET: "{{ tinyauth_pocketid_client_secret }}"
+      TINYAUTH_OAUTH_PROVIDERS_POCKETID_AUTHURL: "https://id.mol.la/authorize"
+      TINYAUTH_OAUTH_PROVIDERS_POCKETID_TOKENURL: "https://id.mol.la/api/oidc/token"
+      TINYAUTH_OAUTH_PROVIDERS_POCKETID_USERINFOURL: "https://id.mol.la/api/oidc/userinfo"
+      TINYAUTH_OAUTH_PROVIDERS_POCKETID_REDIRECTURL: "https://id.mol.la/api/oauth/callback/pocketid"
+      TINYAUTH_OAUTH_PROVIDERS_POCKETID_SCOPES: "openid email profile groups"
+      TINYAUTH_OAUTH_PROVIDERS_POCKETID_NAME: "Pocket ID"
+      TINYAUTH_AUTH_TRUSTEDPROXIES: "192.168.178.121,127.0.0.1,::1"
 
   pocketid:
     image: {{ pocketid_image }}

--- a/roles/vault/tasks/main.yml
+++ b/roles/vault/tasks/main.yml
@@ -57,7 +57,6 @@
     src: /tmp/vault.zip
     dest: /usr/local/bin
     remote_src: true
-    creates: /usr/local/bin/vault
 
 - name: Set Vault binary ownership and permissions
   ansible.builtin.file:


### PR DESCRIPTION
- bump vault_version to 2.0.3
- remove creates: guard in unarchive so version bumps take effect
- pocketid/tinyauth v5 migration + caddy header_up fixes for protected routes
- followed official upgrade guide with full LXC backup and restore test