### PR TITLE
fix(oci): update remaining qwen3 model refs to qwen3:14b

### DIFF
--- a/.github/workflows/oci-ai-inference.yml
+++ b/.github/workflows/oci-ai-inference.yml
@@ -14,7 +14,7 @@ on:
           - deploy
           - destroy
       ollama_model:
-        description: "Ollama model tag (leave blank for default: qwen3:8b)"
+        description: "Ollama model tag (leave blank for default: qwen3:14b)"
         required: false
         default: ""
 
@@ -91,7 +91,7 @@ jobs:
           TF_VAR_availability_domain: ${{ vars.OCI_AVAILABILITY_DOMAIN }}
           TF_VAR_ssh_public_key: ${{ secrets.OCI_SSH_PUBLIC_KEY }}
           TF_VAR_tailscale_auth_key: ${{ secrets.TAILSCALE_AUTH_KEY_OCI }}
-          TF_VAR_ollama_model: ${{ github.event.inputs.ollama_model || 'qwen3:8b' }}
+          TF_VAR_ollama_model: ${{ github.event.inputs.ollama_model || 'qwen3:14b' }}
           AWS_REQUEST_CHECKSUM_CALCULATION: when_required
           AWS_RESPONSE_CHECKSUM_VALIDATION: when_required
         run: terraform plan -out=tfplan -input=false
@@ -119,7 +119,7 @@ jobs:
           TF_VAR_availability_domain: ${{ vars.OCI_AVAILABILITY_DOMAIN }}
           TF_VAR_ssh_public_key: ${{ secrets.OCI_SSH_PUBLIC_KEY }}
           TF_VAR_tailscale_auth_key: ${{ secrets.TAILSCALE_AUTH_KEY_OCI }}
-          TF_VAR_ollama_model: ${{ github.event.inputs.ollama_model || 'qwen3:8b' }}
+          TF_VAR_ollama_model: ${{ github.event.inputs.ollama_model || 'qwen3:14b' }}
           AWS_REQUEST_CHECKSUM_CALCULATION: when_required
           AWS_RESPONSE_CHECKSUM_VALIDATION: when_required
         run: |
@@ -193,7 +193,7 @@ jobs:
         working-directory: ${{ env.ANSIBLE_WORKING_DIR }}
         env:
           ANSIBLE_HOST_KEY_CHECKING: "False"
-          OLLAMA_MODEL: ${{ github.event.inputs.ollama_model || 'qwen3:8b' }}
+          OLLAMA_MODEL: ${{ github.event.inputs.ollama_model || 'qwen3:14b' }}
         run: |
           ansible-playbook playbooks/deploy_oci_ollama.yml \
             -i oci-ai-inference, \
@@ -217,7 +217,7 @@ jobs:
           TF_VAR_availability_domain: ${{ vars.OCI_AVAILABILITY_DOMAIN }}
           TF_VAR_ssh_public_key: ${{ secrets.OCI_SSH_PUBLIC_KEY }}
           TF_VAR_tailscale_auth_key: ${{ secrets.TAILSCALE_AUTH_KEY_OCI }}
-          TF_VAR_ollama_model: ${{ github.event.inputs.ollama_model || 'qwen3:8b' }}
+          TF_VAR_ollama_model: ${{ github.event.inputs.ollama_model || 'qwen3:14b' }}
           AWS_REQUEST_CHECKSUM_CALCULATION: when_required
           AWS_RESPONSE_CHECKSUM_VALIDATION: when_required
         run: terraform destroy -auto-approve -input=false

--- a/roles/oci_ollama/defaults/main.yml
+++ b/roles/oci_ollama/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-ollama_model: "qwen3.6:27b"
+ollama_model: "qwen3:14b"
 ollama_port: 11434
 ollama_keep_alive: "10m"
 ollama_max_loaded_models: 1


### PR DESCRIPTION
## Summary
- `.github/workflows/oci-ai-inference.yml` workflow_dispatch input default and 4 job-step fallbacks still said `qwen3:8b`
- `roles/oci_ollama/defaults/main.yml` (top-level role, the one the playbook actually resolves per CLAUDE.md) still said `qwen3.6:27b`

Follow-up to #155 which missed these two spots.

## Test plan
- [x] `rg qwen3:8b|qwen3\.6` repo-wide returns no hits