### PR TITLE
feat(caddy): add vibejudge.mol.la route to humaun LXC

### DIFF
--- a/roles/caddy/templates/Caddyfile.j2
+++ b/roles/caddy/templates/Caddyfile.j2
@@ -130,6 +130,11 @@ http://dns2.mol.la, dns2.mol.la {
 	reverse_proxy 192.168.178.254:80
 }
 
+# Vibejudge — public web app
+http://vibejudge.mol.la, vibejudge.mol.la {
+    reverse_proxy 192.168.178.252:80
+}
+
 # Timothy — Hermes AI agent dashboard (protected by Tinyauth)
 http://timothy.mol.la, timothy.mol.la {
     import protected


### PR DESCRIPTION
Expose public web app on humaun LXC (192.168.178.252:80) at vibejudge.mol.la via Caddy reverse proxy. No auth — app handles its own. Wildcard DNS already set on Cloudflare + AdGuard.