### PR TITLE
chore(pocketid): bump pocketid to v2.12.0

### DIFF
--- a/roles/pocketid/defaults/main.yml
+++ b/roles/pocketid/defaults/main.yml
@@ -2,5 +2,5 @@
 # Vault path for PocketID secrets (pocketid_encryption_key, tinyauth_pocketid_client_id, tinyauth_pocketid_client_secret)
 pocketid_vault_secret_path: "kv/homelab/data/pocketid"
 
-pocketid_image: "ghcr.io/pocket-id/pocket-id:v2.10.0"
+pocketid_image: "ghcr.io/pocket-id/pocket-id:v2.12.0"
 tinyauth_image: "ghcr.io/steveiliop56/tinyauth:v5.0.7"


### PR DESCRIPTION
Bump pinned pocketid_image v2.10.0 → v2.12.0 (security release). v2.12.0 includes security fixes; v2.11/v2.12 add Francis actor framework DB migrations (auto-run on startup) and drop user-initiated one-time access token login.