### PR TITLE
feat(docker-prune): add weekly image prune timer on Compose hosts

### DIFF
--- a/deployments/deploy_docker_prune.yml
+++ b/deployments/deploy_docker_prune.yml
@@ -1,0 +1,8 @@
+---
+# Install weekly Docker image-prune timer on all Docker Compose hosts.
+# Usage: ./lab deploy docker-prune
+- name: Deploy Docker image prune timer
+  hosts: docker_hosts
+  become: true
+  roles:
+    - docker_prune

--- a/inventory/hosts
+++ b/inventory/hosts
@@ -116,3 +116,17 @@ proxmox_host
 core
 applications
 dns
+
+# Docker Compose hosts — used for the weekly docker-prune timer
+[docker_hosts:children]
+caddy_host
+pocketid_host
+timothy_host
+jellyfin_host
+arr_host
+immich_host
+navidrome_host
+dash_host
+humaun_host
+adguard_primary_host
+adguard_secondary_host

--- a/lab
+++ b/lab
@@ -127,6 +127,7 @@ cmd_deploy() {
     [mongodb]="MongoDB"
     [monitoring]="Prometheus + Grafana"
     [node-exporter]="Node Exporter (all hosts)"
+    [docker-prune]="Weekly Docker image prune timer (all Compose hosts)"
     [pve-exporter]="Proxmox VE metrics exporter"
     [jellyfin]="Jellyfin media server"
     [arr]="*arr stack"
@@ -139,7 +140,7 @@ cmd_deploy() {
   if [[ -z "$service" || -z "${SERVICE_LABELS[$service]+_}" ]]; then
     _header "Deploy — available services"
     for svc in adguard caddy pocketid vault postgresql mysql redis mongodb \
-                monitoring node-exporter pve-exporter jellyfin arr immich navidrome \
+                monitoring node-exporter docker-prune pve-exporter jellyfin arr immich navidrome \
                 tailscale timothy; do
       printf "    ${CYAN}%-18s${RESET} %s\n" "$svc" "${SERVICE_LABELS[$svc]}"
     done
@@ -174,6 +175,7 @@ cmd_deploy() {
     monitoring)    _require_vars vault_auth_vars.yml
                    _run ansible-playbook "$DEPLOYMENTS_DIR/deploy_monitoring.yml" -e "@$VARS_DIR/vault_auth_vars.yml" ;;
     node-exporter) _run ansible-playbook "$DEPLOYMENTS_DIR/deploy_node_exporter.yml" ;;
+    docker-prune)  _run ansible-playbook "$DEPLOYMENTS_DIR/deploy_docker_prune.yml" ;;
     pve-exporter)  _require_vars vault_auth_vars.yml
                    _run ansible-playbook "$DEPLOYMENTS_DIR/deploy_pve_exporter.yml" -e "@$VARS_DIR/vault_auth_vars.yml" ;;
     jellyfin)      _run ansible-playbook "$DEPLOYMENTS_DIR/deploy_jellyfin.yml" ;;

--- a/roles/docker_prune/defaults/main.yml
+++ b/roles/docker_prune/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+docker_prune_schedule: "Sun 04:00"   # systemd OnCalendar

--- a/roles/docker_prune/handlers/main.yml
+++ b/roles/docker_prune/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true

--- a/roles/docker_prune/tasks/main.yml
+++ b/roles/docker_prune/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: Deploy docker-prune service unit
+  ansible.builtin.template:
+    src: docker-prune.service.j2
+    dest: /etc/systemd/system/docker-prune.service
+    mode: '0644'
+  notify: Reload systemd
+
+- name: Deploy docker-prune timer unit
+  ansible.builtin.template:
+    src: docker-prune.timer.j2
+    dest: /etc/systemd/system/docker-prune.timer
+    mode: '0644'
+  notify: Reload systemd
+
+- name: Enable and start docker-prune timer
+  ansible.builtin.systemd:
+    name: docker-prune.timer
+    state: started
+    enabled: true
+    daemon_reload: true

--- a/roles/docker_prune/templates/docker-prune.service.j2
+++ b/roles/docker_prune/templates/docker-prune.service.j2
@@ -1,0 +1,8 @@
+[Unit]
+Description=Prune unused Docker images
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/docker image prune -af

--- a/roles/docker_prune/templates/docker-prune.timer.j2
+++ b/roles/docker_prune/templates/docker-prune.timer.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Weekly Docker image prune
+
+[Timer]
+OnCalendar={{ docker_prune_schedule }}
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Docker accumulates old image layers across `./lab upgrade` runs (pull latest, never remove old). arr/immich root disks hit 95-96%; manual prune reclaimed ~20GB and unblocked a failed immich deploy.

Adds a systemd timer running `docker image prune -af` weekly (Sun 04:00), scoped to a new `docker_hosts` inventory group covering the 11 Compose LXCs. Mirrors the `pve_exporter` role pattern (unit + timer + daemon_reload handler).

```bash
./lab deploy docker-prune
``