### PR TITLE
feat(timothy): deploy Timothy AI agent on LXC 125

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ vars/                    → runtime secrets/config (gitignored); *.example file
 | 192.168.178.131 | MariaDB                           | systemd apt    |
 | 192.168.178.132 | Redis                             | systemd apt    |
 | 192.168.178.133 | MongoDB                           | systemd apt    |
-| 192.168.178.125 | AI agent host                      | Docker Compose |
+| 192.168.178.125 | Timothy (AI agent)                 | Docker Compose |
 | 192.168.178.140 | Jellyfin                          | Docker Compose |
 | 192.168.178.141 | *arr stack                        | Docker Compose |
 | 192.168.178.142 | Immich                            | Docker Compose |
@@ -155,7 +155,7 @@ All secrets live under `kv/homelab/data/<service>` (kv-v2 engine):
 | `kv/homelab/data/caddy`        | `cloudflare_api_token`, `cloudflare_tunnel_token`, `cloudflare_account_email`                                               |
 | `kv/homelab/data/pocketid`     | `pocketid_encryption_key`, `tinyauth_pocketid_client_id`, `tinyauth_pocketid_client_secret`, `pocketid_maxmind_license_key` |
 | `kv/homelab/data/tailscale`    | `auth_key`                                                                                                                  |
-| `kv/homelab/data/timothy`      | `api_server_key`, `ollama_base_url`, `telegram_bot_token`, `glm_api_key`                                                    |
+| `kv/homelab/data/timothy`      | `master_key`, `api_token`, `public_url`, `vault_role_id`, `vault_secret_id` (bootstrap); runtime provider keys written by Timothy's own Vault backend |
 
 Vault reads always use `delegate_to: localhost` + `become: false` (runs on Ansible control, not target host).
 
@@ -183,9 +183,20 @@ terraform {
 }
 ```
 
-### LXC 125 (AI agent host)
+### LXC 125 — Timothy (AI agent)
 
-LXC 125 (`192.168.178.125`, vmid 125) runs user-deployed Docker Compose agents. Tailscale is installed (reaches `oci-ai-inference` over MagicDNS).
+LXC 125 (`192.168.178.125`, vmid 125) runs Timothy (`ghcr.io/timothy-agent/timothy-*`, pinned `timothy_version`). Self-hosted Go/React AI assistant. Tailscale installed (reaches `oci-ai-inference` over MagicDNS for local model fallback).
+
+**Deployment model** — `roles/timothy/` treats Timothy's release assets as upstream: each deploy fetches `docker-compose.yml` + `searxng-settings.yml` fresh from the pinned release tag, then patches the compose to centralize Postgres:
+- Drops the bundled `postgres` service + `pgdata` volume; rewrites `DATABASE_URL` to the central instance (LXC 130, `timothy` db with pgvector).
+- Scrubs dangling `depends_on.postgres` entries.
+- The patch runs via `roles/timothy/templates/patch-compose.py.j2` (PyYAML on the LXC); validated with `docker compose config -q` before start.
+
+**Secrets** — two layers:
+- **Bootstrap** (`master_key`, `api_token`, `public_url`, pg password): fetched from Vault at deploy time into `.env` (Vault-fed, not installer-generated).
+- **Runtime** (LLM provider keys, connector tokens): Timothy's own native Vault backend, using a scoped `timothy` AppRole + `timothy-policy` (read/write on `kv/homelab/data/timothy/*` only — NOT the broad `ansible-read-policy`). Configured post-deploy via Timothy's Settings UI → secret backends.
+
+Image tag pinned (`timothy_version`); bump + redeploy to upgrade. Mission sandbox image pulled explicitly (compose pull doesn't cover env-var-referenced images).
 
 LXC 125 requires `/dev/net/tun` for Tailscale — add to `/etc/pve/lxc/125.conf` on the Proxmox host and restart the container:
 ```

--- a/deployments/deploy_timothy.yml
+++ b/deployments/deploy_timothy.yml
@@ -1,0 +1,9 @@
+---
+# Deploy Timothy (self-hosted AI agent). Central Postgres (LXC 130),
+# Vault-fed .env. Upstream compose fetched live each deploy.
+# Usage: ./lab deploy timothy
+- name: Deploy Timothy
+  hosts: timothy_host
+  become: true
+  roles:
+    - timothy

--- a/lab
+++ b/lab
@@ -134,13 +134,14 @@ cmd_deploy() {
     [immich]="Immich photo/video backup"
     [navidrome]="Navidrome music server"
     [tailscale]="Tailscale (all hosts)"
+    [timothy]="Timothy AI agent"
   )
 
   if [[ -z "$service" || -z "${SERVICE_LABELS[$service]+_}" ]]; then
     _header "Deploy — available services"
     for svc in adguard caddy pocketid vault postgresql mysql redis mongodb \
                 monitoring node-exporter docker-prune pve-exporter jellyfin arr immich navidrome \
-                tailscale; do
+                tailscale timothy; do
       printf "    ${CYAN}%-18s${RESET} %s\n" "$svc" "${SERVICE_LABELS[$svc]}"
     done
     echo ""
@@ -184,6 +185,8 @@ cmd_deploy() {
     navidrome)     _run ansible-playbook "$DEPLOYMENTS_DIR/deploy_navidrome.yml" ;;
     tailscale)     _require_vars vault_auth_vars.yml
                    _run ansible-playbook "$DEPLOYMENTS_DIR/deploy_tailscale.yml" -e "@$VARS_DIR/vault_auth_vars.yml" ;;
+    timothy)       _require_vars vault_auth_vars.yml
+                   _run ansible-playbook "$DEPLOYMENTS_DIR/deploy_timothy.yml" -e "@$VARS_DIR/vault_auth_vars.yml" ;;
   esac
 
   _ok "Deployed ${SERVICE_LABELS[$service]} in $(_elapsed $start)"
@@ -199,6 +202,7 @@ cmd_upgrade() {
     [jellyfin]="192.168.178.140 /opt/compose/jellyfin-jellyfin"
     [arr]="192.168.178.141 /opt/compose/arr-arr"
     [navidrome]="192.168.178.143 /opt/compose/navidrome-navidrome"
+    [timothy]="192.168.178.125 /opt/compose/timothy-timothy"
   )
 
   declare -A PINNED=(

--- a/roles/caddy/templates/Caddyfile.j2
+++ b/roles/caddy/templates/Caddyfile.j2
@@ -134,3 +134,9 @@ http://dns2.mol.la, dns2.mol.la {
 http://vibejudge.mol.la, vibejudge.mol.la {
     reverse_proxy 192.168.178.252:80
 }
+
+# Timothy — self-hosted AI agent (protected by Tinyauth)
+http://timothy.mol.la, timothy.mol.la {
+    import protected
+    reverse_proxy {{ hostvars['timothy'].ansible_host }}:3300
+}

--- a/roles/timothy/defaults/main.yml
+++ b/roles/timothy/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+timothy_vault_secret_path: "kv/homelab/data/timothy"
+timothy_pg_vault_path: "kv/homelab/data/postgresql"
+timothy_version: "v0.1.0-alpha.1"
+timothy_image_namespace: "ghcr.io/timothy-agent"
+timothy_compose_dir: "/opt/compose/timothy-{{ inventory_hostname }}"
+timothy_release_base: "https://github.com/timothy-agent/timothy/releases/download/{{ timothy_version }}"
+timothy_web_port: 3300
+timothy_brain_port: 8300
+timothy_public_url: "https://timothy.mol.la"
+timothy_sandbox_image: "{{ timothy_image_namespace }}/timothy-sandbox:{{ timothy_version }}"
+timothy_pg_host: "192.168.178.130"
+timothy_pg_port: 5432

--- a/roles/timothy/handlers/main.yml
+++ b/roles/timothy/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart Timothy
+  community.docker.docker_compose_v2:
+    project_src: "{{ timothy_compose_dir }}"
+    state: present
+    restarted: true

--- a/roles/timothy/tasks/main.yml
+++ b/roles/timothy/tasks/main.yml
@@ -1,0 +1,100 @@
+---
+- name: Ensure compose project directory exists
+  ansible.builtin.file:
+    path: "{{ timothy_compose_dir }}"
+    state: directory
+    mode: '0755'
+
+- name: Detect docker.sock GID on host
+  ansible.builtin.stat:
+    path: /var/run/docker.sock
+  register: timothy_sock_stat
+
+- name: Set docker sock GID
+  ansible.builtin.set_fact:
+    timothy_docker_sock_gid: "{{ timothy_sock_stat.stat.gid | default(0) }}"
+
+- name: Fetch timothy postgres password from Vault
+  community.hashi_vault.vault_read:
+    url: "{{ vault_addr }}"
+    path: "{{ timothy_pg_vault_path }}"
+    auth_method: approle
+    role_id: "{{ vault_role_id }}"
+    secret_id: "{{ vault_secret_id }}"
+  register: timothy_pg_secret
+  delegate_to: localhost
+  become: false
+  no_log: true
+
+- name: Fetch timothy bootstrap secrets from Vault
+  community.hashi_vault.vault_read:
+    url: "{{ vault_addr }}"
+    path: "{{ timothy_vault_secret_path }}"
+    auth_method: approle
+    role_id: "{{ vault_role_id }}"
+    secret_id: "{{ vault_secret_id }}"
+  register: timothy_secret
+  delegate_to: localhost
+  become: false
+  no_log: true
+
+- name: Fetch upstream docker-compose.yml
+  ansible.builtin.get_url:
+    url: "{{ timothy_release_base }}/docker-compose.yml"
+    dest: "{{ timothy_compose_dir }}/docker-compose.yml"
+    mode: '0644'
+    force: true
+
+- name: Ensure searxng config directory exists
+  ansible.builtin.file:
+    path: "{{ timothy_compose_dir }}/searxng"
+    state: directory
+    mode: '0755'
+
+- name: Fetch upstream searxng settings
+  ansible.builtin.get_url:
+    url: "{{ timothy_release_base }}/searxng-settings.yml"
+    dest: "{{ timothy_compose_dir }}/searxng/settings.yml"
+    mode: '0644'
+    force: true
+
+- name: Drop compose patch script
+  ansible.builtin.template:
+    src: patch-compose.py.j2
+    dest: "{{ timothy_compose_dir }}/patch-compose.py"
+    mode: '0755'
+  no_log: true
+
+- name: Centralize Postgres (drop bundled, rewrite DATABASE_URL)
+  ansible.builtin.command: python3 {{ timothy_compose_dir }}/patch-compose.py
+  changed_when: false
+
+- name: Validate patched compose
+  ansible.builtin.command: docker compose -f {{ timothy_compose_dir }}/docker-compose.yml config -q
+  changed_when: false
+
+- name: Deploy .env from Vault secrets
+  ansible.builtin.template:
+    src: env.j2
+    dest: "{{ timothy_compose_dir }}/.env"
+    mode: '0600'
+  no_log: true
+  notify: Restart Timothy
+
+- name: Pull Timothy images
+  ansible.builtin.command: docker compose -f {{ timothy_compose_dir }}/docker-compose.yml pull
+  changed_when: false
+
+- name: Pull mission sandbox image explicitly
+  ansible.builtin.command: docker pull {{ timothy_sandbox_image }}
+  changed_when: false
+
+- name: Start Timothy
+  community.docker.docker_compose_v2:
+    project_src: "{{ timothy_compose_dir }}"
+    state: present
+
+- name: Wait for web UI
+  ansible.builtin.wait_for:
+    port: "{{ timothy_web_port }}"
+    timeout: 90

--- a/roles/timothy/templates/env.j2
+++ b/roles/timothy/templates/env.j2
@@ -1,0 +1,12 @@
+TIMOTHY_VERSION={{ timothy_version }}
+WEB_PORT={{ timothy_web_port }}
+BRAIN_PORT={{ timothy_brain_port }}
+LOG_LEVEL=info
+TIMOTHY_MASTER_KEY={{ timothy_secret.data.data.data.master_key }}
+TIMOTHY_API_TOKEN={{ timothy_secret.data.data.data.api_token }}
+TIMOTHY_PUBLIC_URL={{ timothy_public_url }}
+MISSION_SANDBOX_IMAGE={{ timothy_sandbox_image }}
+DOCKER_SOCK_GID={{ timothy_docker_sock_gid }}
+# POSTGRES_PASSWORD unused — central PG on LXC 130. Kept to satisfy
+# upstream compose's :? guard (overridden by the patched DATABASE_URL).
+POSTGRES_PASSWORD=unused-central-pg

--- a/roles/timothy/templates/patch-compose.py.j2
+++ b/roles/timothy/templates/patch-compose.py.j2
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Centralize Timothy's Postgres: drop the bundled postgres service + its
+# volume, rewrite DATABASE_URL to the homelab central instance, and scrub
+# the now-dangling depends_on.postgres entries the go-services carry.
+# Run against the upstream docker-compose.yml fetched fresh each deploy.
+import sys
+import yaml
+
+COMPOSE = "{{ timothy_compose_dir }}/docker-compose.yml"
+DB_URL = "postgres://timothy:{{ timothy_pg_secret.data.data.data.timothy }}@{{ timothy_pg_host }}:{{ timothy_pg_port }}/timothy"
+
+with open(COMPOSE) as f:
+    doc = yaml.safe_load(f)
+
+services = doc.get("services", {})
+
+# 1. Drop bundled postgres service.
+services.pop("postgres", None)
+
+# 2. Rewrite DATABASE_URL everywhere it appears (env maps + the &db-env
+#    anchor is resolved into each service's environment by yaml.safe_load,
+#    so editing per-service env catches all of brain/gateway/memoryd).
+for svc in services.values():
+    env = svc.get("environment")
+    if isinstance(env, dict) and "DATABASE_URL" in env:
+        env["DATABASE_URL"] = DB_URL
+    # 3. Scrub dangling depends_on.postgres (upstream uses dict form).
+    dep = svc.get("depends_on")
+    if isinstance(dep, dict):
+        dep.pop("postgres", None)
+        if not dep:
+            svc.pop("depends_on", None)
+
+# 4. Drop pgdata volume (kept workspace/attachments).
+doc.get("volumes", {}).pop("pgdata", None)
+
+with open(COMPOSE, "w") as f:
+    yaml.safe_dump(doc, f, sort_keys=False)
+
+print("patched: postgres service dropped, DATABASE_URL -> central PG")

--- a/roles/vault_config/defaults/main.yml
+++ b/roles/vault_config/defaults/main.yml
@@ -7,6 +7,10 @@ vault_approle_token_max_ttl: "4h"
 vault_approle_secret_id_ttl: "0"
 vault_policy_name: "ansible-read-policy"
 
+# Timothy (own runtime secret backend)
+vault_timothy_policy_name: "timothy-policy"
+vault_timothy_approle_name: "timothy"
+
 # OIDC (PocketID)
 vault_oidc_discovery_url: "https://id.mol.la"
 vault_oidc_role_name: "homelab-admin"

--- a/roles/vault_config/tasks/main.yml
+++ b/roles/vault_config/tasks/main.yml
@@ -72,6 +72,52 @@
       - "Store these securely. The secret_id cannot be retrieved again."
   # Intentionally not no_log — operator needs these values once during bootstrap.
 
+# --- Timothy (own runtime secret backend) ---
+
+- name: Write timothy-policy
+  community.hashi_vault.vault_write:
+    url: "{{ vault_addr }}"
+    token: "{{ vault_token }}"
+    path: "sys/policies/acl/{{ vault_timothy_policy_name }}"
+    data:
+      policy: "{{ lookup('template', 'timothy-policy.hcl.j2') }}"
+
+- name: Create timothy AppRole
+  community.hashi_vault.vault_write:
+    url: "{{ vault_addr }}"
+    token: "{{ vault_token }}"
+    path: "auth/approle/role/{{ vault_timothy_approle_name }}"
+    data:
+      token_policies:
+        - "{{ vault_timothy_policy_name }}"
+      token_ttl: "{{ vault_approle_token_ttl }}"
+      token_max_ttl: "{{ vault_approle_token_max_ttl }}"
+      secret_id_ttl: "{{ vault_approle_secret_id_ttl }}"
+
+- name: Read timothy AppRole role-id
+  community.hashi_vault.vault_read:
+    url: "{{ vault_addr }}"
+    token: "{{ vault_token }}"
+    path: "auth/approle/role/{{ vault_timothy_approle_name }}/role-id"
+  register: timothy_approle_role_id
+  no_log: true
+
+- name: Generate timothy AppRole secret-id
+  community.hashi_vault.vault_write:
+    url: "{{ vault_addr }}"
+    token: "{{ vault_token }}"
+    path: "auth/approle/role/{{ vault_timothy_approle_name }}/secret-id"
+  register: timothy_approle_secret_id
+  no_log: true
+
+- name: Display timothy AppRole credentials
+  ansible.builtin.debug:
+    msg:
+      - "timothy role_id: {{ timothy_approle_role_id.data.data.role_id }}"
+      - "timothy secret_id: {{ timothy_approle_secret_id.data.data.secret_id }}"
+      - "Store these in kv/homelab/data/timothy as vault_role_id / vault_secret_id. The secret_id cannot be retrieved again."
+  # Intentionally not no_log — operator needs these values once during bootstrap.
+
 # --- OIDC (PocketID) ---
 
 - name: Write admin policy

--- a/roles/vault_config/templates/timothy-policy.hcl.j2
+++ b/roles/vault_config/templates/timothy-policy.hcl.j2
@@ -1,0 +1,8 @@
+# Read/write for Timothy's own secret backend — scoped to its own path only
+path "{{ vault_kv_path }}/data/timothy/*" {
+  capabilities = ["create", "read", "update", "list"]
+}
+
+path "{{ vault_kv_path }}/metadata/timothy/*" {
+  capabilities = ["read", "list"]
+}


### PR DESCRIPTION
Deploys Timothy (self-hosted Go/React AI agent, `ghcr.io/timothy-agent/timothy-*`, pinned `v0.1.0-alpha.1`) onto LXC 125.

**Upstream-as-source:** role fetches `docker-compose.yml` + `searxng-settings.yml` fresh from the release tag each deploy, then patches compose to centralize Postgres (drop bundled postgres + pgdata, rewrite DATABASE_URL → LXC 130 `timothy` db w/ pgvector, scrub dangling depends_on). Validated via `docker compose config -q`.

**Secrets:** Vault-fed `.env` for bootstrap (master_key, api_token, public_url, pg password). Timothy's own native Vault backend uses a new scoped `timothy` AppRole + `timothy-policy` (read/write on `kv/homelab/data/timothy/*`), configured post-deploy via Settings UI.

**Blocked on:** Vault secret seeding (needs root token) — keeping draft until seeded + deploy verified.