### PR TITLE
fix(timothy): load .env for compose validate + pull

### DIFF
--- a/roles/timothy/tasks/main.yml
+++ b/roles/timothy/tasks/main.yml
@@ -69,10 +69,6 @@
   ansible.builtin.command: python3 {{ timothy_compose_dir }}/patch-compose.py
   changed_when: false
 
-- name: Validate patched compose
-  ansible.builtin.command: docker compose -f {{ timothy_compose_dir }}/docker-compose.yml config -q
-  changed_when: false
-
 - name: Deploy .env from Vault secrets
   ansible.builtin.template:
     src: env.j2
@@ -81,8 +77,29 @@
   no_log: true
   notify: Restart Timothy
 
+- name: Validate patched compose
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - --env-file
+      - "{{ timothy_compose_dir }}/.env"
+      - -f
+      - "{{ timothy_compose_dir }}/docker-compose.yml"
+      - config
+      - -q
+  changed_when: false
+
 - name: Pull Timothy images
-  ansible.builtin.command: docker compose -f {{ timothy_compose_dir }}/docker-compose.yml pull
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - --env-file
+      - "{{ timothy_compose_dir }}/.env"
+      - -f
+      - "{{ timothy_compose_dir }}/docker-compose.yml"
+      - pull
   changed_when: false
 
 - name: Pull mission sandbox image explicitly


### PR DESCRIPTION
First deploy failed: `docker compose config -q` ran before `.env` existed and without project-dir context, so TIMOTHY_VERSION/POSTGRES_PASSWORD were unset. Reorder .env deploy before validate, pass --env-file to validate + pull commands.