### PR TITLE
fix(timothy): drop unsupported restarted param from handler

### DIFF
--- a/roles/timothy/handlers/main.yml
+++ b/roles/timothy/handlers/main.yml
@@ -3,4 +3,3 @@
   community.docker.docker_compose_v2:
     project_src: "{{ timothy_compose_dir }}"
     state: present
-    restarted: true


### PR DESCRIPTION
Handler failed post-deploy: docker_compose_v2 has no 'restarted' param in installed collection version. Match immich/jellyfin shape (state: present).