### PR TITLE
feat(postgresql): pin PG18 from pgdg repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,7 @@ Install before first run: `ansible-galaxy install -r requirements.yml`
 - Caddy uses a custom Dockerfile (in `roles/caddy/files/`) that builds the Cloudflare DNS plugin via `xcaddy`; runs in `network_mode: host`
 - Caddy Caddyfile defines a reusable `(protected)` snippet for Tinyauth forward-auth; import it with `import protected` on protected routes
 - Database roles (postgresql, mysql, mongodb) have a `create_app.yml` task file separate from `main.yml` — included by playbooks that need per-app users/databases. PostgreSQL apps also specify extensions (e.g. `vector`, `earthdistance` for Immich).
-- PostgreSQL has pgvector installed for Immich; `pg_hba.conf` is templated
+- PostgreSQL is pinned to PG18 (from the pgdg apt repo, `postgresql_version` var in `roles/postgresql/defaults/main.yml`); pgvector installed for Immich + Timothy; `pg_hba.conf` is templated. Major-version upgrades require a manual `pg_upgradecluster` run (not handled by the role).
 - Monitoring: Prometheus node targets auto-derive from `proxmox_containers` in `inventory/group_vars/all/lxc.yml` — adding an LXC there and redeploying monitoring is sufficient
 - AdGuard Primary runs in host network mode (required for DHCP broadcasts); Secondary uses bridge
 - *arr stack runs as uid/gid 0:0 — unprivileged LXC quirk so containers can write to bind-mounted media

--- a/roles/postgresql/defaults/main.yml
+++ b/roles/postgresql/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 postgres_homelab_network: "192.168.178.0/24"
 postgres_vault_secret_path: "kv/homelab/data/postgresql"
+# Pinned major version; installed from the postgresql.org (pgdg) apt repo.
+# Bump + run pg_upgradecluster <old> main manually for a major upgrade.
+postgresql_version: "18"
 
 # List of apps — each gets a user, db, and pg_hba rule.
 # Password is fetched from Vault using vault_key.

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -1,9 +1,29 @@
 ---
-- name: Install PostgreSQL and Python bindings
+- name: Ensure postgresql.org apt repo (pgdg) keyring present
+  ansible.builtin.file:
+    path: /usr/share/postgresql-common/pgdg
+    state: directory
+    mode: '0755'
+
+- name: Download pgdg apt signing key
+  ansible.builtin.get_url:
+    url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
+    dest: /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+    mode: '0644'
+    force: true
+
+- name: Add pgdg apt repo
+  ansible.builtin.apt_repository:
+    repo: "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt {{ ansible_distribution_release }}-pgdg main"
+    filename: pgdg
+    state: present
+    update_cache: true
+
+- name: Install PostgreSQL {{ postgresql_version }} + Python bindings + pgvector
   ansible.builtin.apt:
     name:
-      - postgresql
-      - postgresql-contrib
+      - "postgresql-{{ postgresql_version }}"
+      - "postgresql-{{ postgresql_version }}-pgvector"
       - python3-psycopg2
     state: present
     update_cache: true


### PR DESCRIPTION
Central PG upgraded 16→18 in place (pg_upgradecluster, already done on LXC 130) to match Timothy's bundled PG18 for the upcoming data migration. Role now adds the postgresql.org (pgdg) apt repo and installs version-pinned `postgresql-18` + `postgresql-18-pgvector` instead of Ubuntu's default PG16. `postgresql_version` var controls the major version; major upgrades still manual via pg_upgradecluster.