### PR TITLE
chore(postgresql): add timothy app entry

### DIFF
--- a/vars/postgresql_apps.yml
+++ b/vars/postgresql_apps.yml
@@ -7,3 +7,7 @@ postgres_apps:
     vault_key: immich
     vector_extension: true
     earthdistance_extension: true
+  - user: timothy
+    db: timothy
+    vault_key: timothy
+    vector_extension: true


### PR DESCRIPTION
## Summary
- Add `timothy` to `postgres_apps` in `vars/postgresql_apps.yml`, syncing the repo with a change previously applied directly on the ansible host during the Timothy deploy.

## Test plan
- [x] Verified ansible-control and local repo now match after commit