### PR TITLE
chore(tinyauth): bump to v5.1.3

### DIFF
--- a/roles/pocketid/defaults/main.yml
+++ b/roles/pocketid/defaults/main.yml
@@ -3,4 +3,4 @@
 pocketid_vault_secret_path: "kv/homelab/data/pocketid"
 
 pocketid_image: "ghcr.io/pocket-id/pocket-id:v2.12.0"
-tinyauth_image: "ghcr.io/steveiliop56/tinyauth:v5.0.7"
+tinyauth_image: "ghcr.io/steveiliop56/tinyauth:v5.1.3"


### PR DESCRIPTION
## Summary
- Bump `tinyauth_image` from v5.0.7 to v5.1.3.
- Pulls in security fixes from GHSA-456h, GHSA-328g, GHSA-9xhm, GHSA-r27r plus deny-by-default ACL hardening (v5.1.0). No config changes needed for this repo's forward-auth-only usage.

## Test plan
- [ ] Deploy pocketid role, verify Tinyauth container starts healthy
- [ ] Confirm protected routes (import protected) still auth correctly via Tinyauth