### PR TITLE
fix(tinyauth): correct GHCR namespace after project move

### DIFF
--- a/roles/pocketid/defaults/main.yml
+++ b/roles/pocketid/defaults/main.yml
@@ -3,4 +3,4 @@
 pocketid_vault_secret_path: "kv/homelab/data/pocketid"
 
 pocketid_image: "ghcr.io/pocket-id/pocket-id:v2.12.0"
-tinyauth_image: "ghcr.io/steveiliop56/tinyauth:v5.1.3"
+tinyauth_image: "ghcr.io/tinyauthapp/tinyauth:v5.1.3"


### PR DESCRIPTION
## Summary
- Tinyauth's image moved from `ghcr.io/steveiliop56/tinyauth` to `ghcr.io/tinyauthapp/tinyauth` following an upstream org rename. The old namespace doesn't publish v5.1.x tags, causing `manifest unknown` on deploy.

## Test plan
- [ ] Redeploy pocketid role, confirm tinyauth container pulls v5.1.3 and starts healthy