### PR TITLE
chore(timothy): bump to v0.1.0-alpha.2

### DIFF
--- a/roles/timothy/defaults/main.yml
+++ b/roles/timothy/defaults/main.yml
@@ -2,7 +2,7 @@
 timothy_vault_secret_path: "kv/homelab/data/timothy"
 timothy_pg_vault_path: "kv/homelab/data/postgresql"
 # TIMOTHY_VERSION (image tag) is bare; GitHub release tag adds a 'v' prefix.
-timothy_version: "0.1.0-alpha.1"
+timothy_version: "0.1.0-alpha.2"
 timothy_release_tag: "v{{ timothy_version }}"
 timothy_image_namespace: "ghcr.io/timothy-agent"
 timothy_compose_dir: "/opt/compose/timothy-{{ inventory_hostname }}"


### PR DESCRIPTION
## Summary
- Bump `timothy_version` from 0.1.0-alpha.1 to 0.1.0-alpha.2. Role fetches release assets fresh from the new tag on next deploy.

## Test plan
- [ ] Deploy timothy role, confirm all 8 containers healthy
- [ ] Log into timothy.mol.la, verify chat still works