### PR TITLE
chore(timothy): bump LXC 125 to 8GB RAM / 4GB swap

### DIFF
--- a/inventory/group_vars/all/lxc.yml
+++ b/inventory/group_vars/all/lxc.yml
@@ -41,7 +41,8 @@ proxmox_containers:
     description: "AI agent host (Docker Compose)"
     unprivileged: 1
     cores: 2
-    memory: 4096
+    memory: 8192
+    swap: 4096
     disk: "local-lvm:30"
   - vmid: 130
     hostname: postgresql


### PR DESCRIPTION
## Summary
- Timothy LXC (vmid 125) resource bump: memory 4096→8192, swap 512→4096
- Applied live via `pct set 125 -memory 8192 -swap 4096` on Proxmox host (no restart needed, hotplugged)
- This commit updates `inventory/group_vars/all/lxc.yml` to match live state (IaC drift fix)

## Test plan
- [x] `pct config 125` confirms memory=8192, swap=4096
- [x] `pct status 125` confirms container still running