### PR TITLE
feat: ship timothy metrics and logs to monitoring stack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ vars/                    → runtime secrets/config (gitignored); *.example file
 | 192.168.178.121 | Caddy (reverse proxy + Tunnel)    | Docker Compose |
 | 192.168.178.122 | PocketID (OIDC) + Tinyauth        | Docker Compose |
 | 192.168.178.123 | Vault                             | systemd binary |
-| 192.168.178.124 | Monitoring (Prometheus + Grafana) | systemd apt    |
+| 192.168.178.124 | Monitoring (Prometheus + Grafana + Loki) | systemd apt    |
 | 192.168.178.130 | PostgreSQL                        | systemd apt    |
 | 192.168.178.131 | MariaDB                           | systemd apt    |
 | 192.168.178.132 | Redis                             | systemd apt    |
@@ -136,6 +136,7 @@ Install before first run: `ansible-galaxy install -r requirements.yml`
 - Database roles (postgresql, mysql, mongodb) have a `create_app.yml` task file separate from `main.yml` — included by playbooks that need per-app users/databases. PostgreSQL apps also specify extensions (e.g. `vector`, `earthdistance` for Immich).
 - PostgreSQL is pinned to PG18 (from the pgdg apt repo, `postgresql_version` var in `roles/postgresql/defaults/main.yml`); pgvector installed for Immich + Timothy; `pg_hba.conf` is templated. Major-version upgrades require a manual `pg_upgradecluster` run (not handled by the role).
 - Monitoring: Prometheus node targets auto-derive from `proxmox_containers` in `inventory/group_vars/all/lxc.yml` — adding an LXC there and redeploying monitoring is sufficient
+- Logs: Loki (LXC 124, port 3100 for log push) aggregates Docker container logs shipped by Promtail, deployed as its own Compose project per log-emitting host (`roles/promtail/`, `./lab deploy promtail`) — reads `/var/run/docker.sock` directly, no app-compose changes needed. App-specific `/metrics` endpoints (e.g. Timothy's brain) are added as their own Prometheus job (`prometheus_<service>_targets` in `roles/monitoring/defaults/main.yml`), following the `immich`/`navidrome`/`timothy` job pattern in `prometheus.yml.j2` — UFW allow rule for the scraped port lives in the target service's own role (see `roles/timothy/tasks/main.yml`), scoped to `src: 192.168.178.124`.
 - AdGuard Primary runs in host network mode (required for DHCP broadcasts); Secondary uses bridge
 - *arr stack runs as uid/gid 0:0 — unprivileged LXC quirk so containers can write to bind-mounted media
 - Media bind-mount directories are set to 0777 on the Proxmox host (see `deployments/create_lxc.yml`) to allow unprivileged container writes

--- a/deployments/deploy_promtail.yml
+++ b/deployments/deploy_promtail.yml
@@ -1,0 +1,8 @@
+---
+# Deploy Promtail (ships Docker container logs to Loki on monitoring LXC).
+# Usage: ./lab deploy promtail
+- name: Deploy Promtail
+  hosts: timothy_host
+  become: true
+  roles:
+    - promtail

--- a/roles/monitoring/defaults/main.yml
+++ b/roles/monitoring/defaults/main.yml
@@ -4,6 +4,10 @@ grafana_port: 3000
 prometheus_scrape_interval: "15s"
 prometheus_retention: "30d"
 
+loki_port: 3100
+loki_retention_days: 30
+loki_data_dir: /var/lib/loki
+
 prometheus_scrape_jobs:
   - job_name: prometheus
     targets: ["localhost:9090"]
@@ -22,6 +26,9 @@ prometheus_immich_targets:
 
 prometheus_navidrome_targets:
   - { addr: "{{ prometheus_navidrome_host | default('192.168.178.143') }}:4533", name: "navidrome" }
+
+prometheus_timothy_targets:
+  - { addr: "{{ prometheus_timothy_host | default('192.168.178.125') }}:8300", name: "timothy-brain" }
 
 # PVE exporter
 pve_exporter_target: "192.168.178.110"

--- a/roles/monitoring/handlers/main.yml
+++ b/roles/monitoring/handlers/main.yml
@@ -8,3 +8,8 @@
   ansible.builtin.service:
     name: grafana-server
     state: restarted
+
+- name: Restart Loki
+  ansible.builtin.service:
+    name: loki
+    state: restarted

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -67,6 +67,44 @@
     state: present
     update_cache: true
 
+# Loki (log aggregation) — same apt.grafana.com repo added above for Grafana.
+- name: Install Loki
+  ansible.builtin.apt:
+    name: loki
+    state: present
+
+- name: Deploy loki-config.yml
+  ansible.builtin.template:
+    src: loki-config.yml.j2
+    dest: /etc/loki/config.yml
+    mode: '0644'
+    owner: loki
+    group: loki
+  notify: Restart Loki
+
+- name: Ensure Loki is running and enabled
+  ansible.builtin.service:
+    name: loki
+    state: started
+    enabled: true
+
+- name: Deploy Grafana Loki datasource provisioning
+  ansible.builtin.template:
+    src: grafana-datasource-loki.yml.j2
+    dest: /etc/grafana/provisioning/datasources/loki.yml
+    mode: '0640'
+    owner: root
+    group: grafana
+  notify: Restart Grafana
+
+- name: Allow Timothy host to push logs to Loki (port {{ loki_port }})
+  community.general.ufw:
+    rule: allow
+    port: "{{ loki_port | string }}"
+    proto: tcp
+    src: "192.168.178.125"
+  when: ansible_facts['os_family'] == 'Debian'
+
 - name: Fetch Grafana OIDC credentials from Vault
   community.hashi_vault.vault_read:
     url: "{{ vault_addr }}"

--- a/roles/monitoring/templates/grafana-datasource-loki.yml.j2
+++ b/roles/monitoring/templates/grafana-datasource-loki.yml.j2
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+deleteDatasources:
+  - name: Loki
+    orgId: 1
+
+datasources:
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://localhost:{{ loki_port }}
+    editable: true

--- a/roles/monitoring/templates/loki-config.yml.j2
+++ b/roles/monitoring/templates/loki-config.yml.j2
@@ -1,0 +1,33 @@
+auth_enabled: false
+
+server:
+  http_listen_port: {{ loki_port }}
+  grpc_listen_port: 9096
+
+common:
+  path_prefix: {{ loki_data_dir }}
+  storage:
+    filesystem:
+      chunks_directory: {{ loki_data_dir }}/chunks
+      rules_directory: {{ loki_data_dir }}/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: {{ loki_retention_days }}d
+
+compactor:
+  working_directory: {{ loki_data_dir }}/compactor
+  retention_enabled: true

--- a/roles/monitoring/templates/prometheus.yml.j2
+++ b/roles/monitoring/templates/prometheus.yml.j2
@@ -36,6 +36,14 @@ scrape_configs:
           instance: "{{ node.name }}"
 {% endfor %}
 
+  - job_name: "timothy"
+    static_configs:
+{% for node in prometheus_timothy_targets | default([]) %}
+      - targets: ["{{ node.addr }}"]
+        labels:
+          instance: "{{ node.name }}"
+{% endfor %}
+
   - job_name: "pve"
     scrape_interval: 30s
     scrape_timeout: 30s

--- a/roles/promtail/defaults/main.yml
+++ b/roles/promtail/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# Promtail — ships this host's Docker container logs to Loki on the
+# monitoring LXC. Runs as its own Compose project, separate from the
+# service(s) whose logs it collects.
+promtail_image: grafana/promtail:latest
+promtail_loki_push_url: "http://192.168.178.124:3100/loki/api/v1/push"

--- a/roles/promtail/handlers/main.yml
+++ b/roles/promtail/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart Promtail
+  community.docker.docker_compose_v2:
+    project_src: "/opt/compose/promtail-{{ inventory_hostname }}"
+    state: present

--- a/roles/promtail/tasks/main.yml
+++ b/roles/promtail/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Ensure Promtail compose project directory exists
+  ansible.builtin.file:
+    path: "/opt/compose/promtail-{{ inventory_hostname }}"
+    state: directory
+    mode: '0755'
+
+- name: Deploy Promtail config
+  ansible.builtin.template:
+    src: promtail-config.yml.j2
+    dest: "/opt/compose/promtail-{{ inventory_hostname }}/promtail-config.yml"
+    mode: '0644'
+  notify: Restart Promtail
+
+- name: Deploy Promtail compose file
+  ansible.builtin.template:
+    src: compose.yml.j2
+    dest: "/opt/compose/promtail-{{ inventory_hostname }}/compose.yml"
+    mode: '0644'
+  notify: Restart Promtail
+
+- name: Start Promtail with Docker Compose
+  community.docker.docker_compose_v2:
+    project_src: "/opt/compose/promtail-{{ inventory_hostname }}"
+    state: present
+    pull: always

--- a/roles/promtail/templates/compose.yml.j2
+++ b/roles/promtail/templates/compose.yml.j2
@@ -1,0 +1,9 @@
+services:
+  promtail:
+    image: {{ promtail_image }}
+    container_name: promtail-{{ inventory_hostname }}
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./promtail-config.yml:/etc/promtail/config.yml:ro
+    command: -config.file=/etc/promtail/config.yml

--- a/roles/promtail/templates/promtail-config.yml.j2
+++ b/roles/promtail/templates/promtail-config.yml.j2
@@ -1,0 +1,23 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: {{ promtail_loki_push_url }}
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 15s
+    relabel_configs:
+      - source_labels: [__meta_docker_container_name]
+        regex: "/(.*)"
+        target_label: container
+      - source_labels: [__meta_docker_container_label_com_docker_compose_project]
+        target_label: compose_project
+      - replacement: "{{ inventory_hostname }}"
+        target_label: host

--- a/roles/timothy/tasks/main.yml
+++ b/roles/timothy/tasks/main.yml
@@ -115,3 +115,11 @@
   ansible.builtin.wait_for:
     port: "{{ timothy_web_port }}"
     timeout: 90
+
+- name: Allow monitoring host to scrape Timothy brain metrics (port {{ timothy_brain_port }})
+  community.general.ufw:
+    rule: allow
+    port: "{{ timothy_brain_port | string }}"
+    proto: tcp
+    src: "192.168.178.124"
+  when: ansible_facts['os_family'] == 'Debian'


### PR DESCRIPTION
## Summary
- Loki added to monitoring LXC (124), same apt.grafana.com repo already used for Grafana
- Prometheus `timothy` scrape job for brain `/metrics` (8300), UFW allow from monitoring LXC
- New `roles/promtail/` role: standalone Compose project on Timothy LXC shipping container logs to Loki via `docker_sd_configs`, no changes to Timothy's own upstream compose

## Test plan
- [ ] `./lab deploy monitoring` — Loki + Grafana datasource + timothy scrape job
- [ ] `./lab deploy timothy` — opens UFW 8300 from monitoring LXC
- [ ] `./lab deploy promtail` — ships timothy container logs
- [ ] Verify Grafana Explore shows Loki logs for timothy containers
- [ ] Verify Prometheus targets page shows `timothy` job up