### PR TITLE
fix: loki config owner group has no matching system group

### DIFF
--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -79,7 +79,7 @@
     dest: /etc/loki/config.yml
     mode: '0644'
     owner: loki
-    group: loki
+    group: nogroup
   notify: Restart Loki
 
 - name: Ensure Loki is running and enabled


### PR DESCRIPTION
## Summary
- Deploy of #171 failed on "chgrp failed: failed to look up group loki" — Loki's .deb creates a `loki` user but no `loki` group (user's gid is `nogroup`/65534)
- Switch template task's `group:` to `nogroup`

## Test plan
- [x] Verified on monitoring LXC: `getent passwd loki` → `loki:x:109:65534::/nonexistent:/bin/false`
- [ ] `./lab deploy monitoring` completes without the chgrp error