### PR TITLE
fix: loki compactor needs delete_request_store when retention enabled

### DIFF
--- a/roles/monitoring/templates/loki-config.yml.j2
+++ b/roles/monitoring/templates/loki-config.yml.j2
@@ -30,4 +30,5 @@ limits_config:
 
 compactor:
   working_directory: {{ loki_data_dir }}/compactor
+  delete_request_store: filesystem
   retention_enabled: true


### PR DESCRIPTION
## Summary
- Loki service was crashlooping post #171 deploy: `CONFIG ERROR: invalid compactor config: compactor.delete-request-store should be configured when retention is enabled`
- Loki 3.7.6 requires `compactor.delete_request_store` whenever `retention_enabled: true` is set

## Test plan
- [x] Confirmed via journalctl on monitoring LXC (124): repeated crashloop with the exact error above
- [ ] `./lab deploy monitoring`, then `systemctl status loki` shows active/running, not activating/auto-restart