### PR TITLE
fix: create loki data directory with correct ownership

### DIFF
--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -73,6 +73,14 @@
     name: loki
     state: present
 
+- name: Ensure Loki data directory exists with correct ownership
+  ansible.builtin.file:
+    path: "{{ loki_data_dir }}"
+    state: directory
+    mode: '0750'
+    owner: loki
+    group: nogroup
+
 - name: Deploy loki-config.yml
   ansible.builtin.template:
     src: loki-config.yml.j2


### PR DESCRIPTION
## Summary
- Loki was hitting systemd's restart rate limit after the compactor fix (#174): "mkdir /var/lib/loki: permission denied"
- The .deb package never creates /var/lib/loki; add an explicit directory task, owner loki:nogroup

## Test plan
- [x] Confirmed via journalctl: "error running loki" err="mkdir /var/lib/loki: permission denied"
- [ ] ./lab deploy monitoring, then systemctl is-active loki -> active