### PR TITLE
fix: bump timothy_version pin to alpha.54, stuck at alpha.2

### DIFF
--- a/roles/timothy/defaults/main.yml
+++ b/roles/timothy/defaults/main.yml
@@ -2,7 +2,7 @@
 timothy_vault_secret_path: "kv/homelab/data/timothy"
 timothy_pg_vault_path: "kv/homelab/data/postgresql"
 # TIMOTHY_VERSION (image tag) is bare; GitHub release tag adds a 'v' prefix.
-timothy_version: "0.1.0-alpha.2"
+timothy_version: "0.1.0-alpha.54"
 timothy_release_tag: "v{{ timothy_version }}"
 timothy_image_namespace: "ghcr.io/timothy-agent"
 timothy_compose_dir: "/opt/compose/timothy-{{ inventory_hostname }}"


### PR DESCRIPTION
## Summary
- roles/timothy default pin never moved past the initial alpha.2 release
- Today's Vault-recovery redeploy pulled that ancient image image against the already-migrated (alpha.54) schema, breaking mission list/recovery with "column budget_usd does not exist" (renamed to budget_amount/budget_currency long ago)
- DB schema itself is already correct at alpha.54 — no ALTERs needed, this is purely the version pin

## Test plan
- [x] Confirmed via docker inspect: running image was ghcr.io/timothy-agent/timothy-brain:0.1.0-alpha.2
- [x] Confirmed DB schema already has budget_amount/budget_currency, no budget_usd on missions
- [ ] ./lab deploy timothy pulls alpha.54, /v1/missions returns 200