### PR TITLE
feat: add Timothy logs dashboard to Grafana

### DIFF
--- a/roles/monitoring/files/dashboards/timothy-logs.json
+++ b/roles/monitoring/files/dashboards/timothy-logs.json
@@ -1,0 +1,116 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "limit": 100,
+        "name": "Annotations & Alerts",
+        "showIn": 0,
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Timothy container logs (Loki) — filter by service and log level",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum by (container) (count_over_time({compose_project=\"timothy\", container=~\"$container\"} | json | level=~\"(?i)$level\" [1m]))",
+          "legendFormat": "{{container}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Log volume by container",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "gridPos": { "h": 22, "w": 24, "x": 0, "y": 6 },
+      "id": 2,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{compose_project=\"timothy\", container=~\"$container\"} | json | level=~\"(?i)$level\"",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs",
+      "type": "logs"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["timothy"],
+  "templating": {
+    "list": [
+      {
+        "current": { "text": "All", "value": "$__all" },
+        "datasource": { "type": "loki", "uid": "loki" },
+        "definition": "label_values({compose_project=\"timothy\"}, container)",
+        "includeAll": true,
+        "label": "Service",
+        "multi": true,
+        "name": "container",
+        "options": [],
+        "query": { "label": "container", "stream": "{compose_project=\"timothy\"}", "type": 1 },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": { "text": "All", "value": "$__all" },
+        "includeAll": true,
+        "label": "Level",
+        "multi": true,
+        "name": "level",
+        "options": [
+          { "text": "All", "value": "$__all", "selected": true },
+          { "text": "info", "value": "info" },
+          { "text": "warn", "value": "warn" },
+          { "text": "error", "value": "error" },
+          { "text": "debug", "value": "debug" }
+        ],
+        "query": "info,warn,error,debug",
+        "queryValue": "",
+        "type": "custom"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "Europe/Amsterdam",
+  "title": "Timothy Logs",
+  "uid": "timothy-logs",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## Summary
- New Grafana dashboard (roles/monitoring/files/dashboards/timothy-logs.json), auto-picked up by monitoring role's existing with_fileglob dashboard copy task
- Log volume timeseries by container + a scrollable logs panel
- Template variables: Service (container name, multi-select, derived from Loki label_values) and Level (info/warn/error/debug, case-insensitive since brain emits uppercase)

## Test plan
- [x] Confirmed brain log JSON shape via direct Loki query: {"level":"INFO",...}
- [ ] ./lab deploy monitoring, dashboard appears under Grafana > Dashboards > Timothy Logs
- [ ] Service filter dropdown lists timothy-brain-1, timothy-gateway-1, etc.