### PR TITLE
chore(timothy): bump timothy_version pin to alpha.55

### DIFF
--- a/roles/timothy/defaults/main.yml
+++ b/roles/timothy/defaults/main.yml
@@ -2,7 +2,7 @@
 timothy_vault_secret_path: "kv/homelab/data/timothy"
 timothy_pg_vault_path: "kv/homelab/data/postgresql"
 # TIMOTHY_VERSION (image tag) is bare; GitHub release tag adds a 'v' prefix.
-timothy_version: "0.1.0-alpha.54"
+timothy_version: "0.1.0-alpha.55"
 timothy_release_tag: "v{{ timothy_version }}"
 timothy_image_namespace: "ghcr.io/timothy-agent"
 timothy_compose_dir: "/opt/compose/timothy-{{ inventory_hostname }}"


### PR DESCRIPTION
## Summary
- Bumps the Timothy image pin to v0.1.0-alpha.55.
- Ships timothy-agent/timothy#332: mission-executor route-preview fix, harness default label, and memory pending-dedup.
- No migrations in this release.

## Test plan
- [x] `./lab deploy timothy` after merge